### PR TITLE
Add static constructor initializer

### DIFF
--- a/Dntc.Cli/Transpiler.cs
+++ b/Dntc.Cli/Transpiler.cs
@@ -1,6 +1,7 @@
 ﻿using Dntc.Common;
 using Dntc.Common.Conversion;
 using Dntc.Common.Definitions;
+using Dntc.Common.Definitions.CustomDefinedMethods;
 using Dntc.Common.Dependencies;
 using Dntc.Common.Planning;
 using Mono.Cecil;

--- a/Dntc.Cli/Transpiler.cs
+++ b/Dntc.Cli/Transpiler.cs
@@ -29,7 +29,7 @@ public class Transpiler
         definitionCatalog.Add(CustomDefinedMethod.StandardCustomMethods);
         definitionCatalog.Add(modules.SelectMany(x => x.Types)); // adding types via type definition automatically adds its methods
 
-        var implementationPlan = new ImplementationPlan(conversionCatalog);
+        var implementationPlan = new ImplementationPlan(conversionCatalog, definitionCatalog);
         foreach (var methodId in _manifest.MethodsToTranspile)
         {
             var foundMethod = definitionCatalog.Get(new IlMethodId(methodId.Trim()));

--- a/Dntc.Common/Conversion/ConversionCatalog.cs
+++ b/Dntc.Common/Conversion/ConversionCatalog.cs
@@ -1,4 +1,5 @@
 ﻿using Dntc.Common.Definitions;
+using Dntc.Common.Definitions.CustomDefinedMethods;
 using Dntc.Common.Dependencies;
 
 namespace Dntc.Common.Conversion;
@@ -93,7 +94,34 @@ public class ConversionCatalog
             }
             
             AddChildren(node);
-            _methods.Add(node.MethodId, new MethodConversionInfo(definition, this));
+            var conversionInfo = new MethodConversionInfo(definition, this);
+            _methods.Add(node.MethodId, conversionInfo);
+
+            if (node.IsStaticConstructor)
+            {
+                var initializerDefinition =
+                    _definitionCatalog.Get(StaticConstructorInitializerDefinedMethod.MethodId);
+
+                if (initializerDefinition == null)
+                {
+                    var message = "No static constructor initializer definition found.";
+                    throw new InvalidOperationException(message);
+                }
+
+                if (initializerDefinition is not StaticConstructorInitializerDefinedMethod initMethodDefinition)
+                {
+                    var message = $"Unexpected type of static constructor initialization method " +
+                                  $"of {initializerDefinition.GetType().FullName}";
+
+                    throw new InvalidOperationException(message);
+                }
+
+                _methods.TryAdd(
+                    initializerDefinition.Id,
+                    new MethodConversionInfo(initializerDefinition, this));
+                
+                initMethodDefinition.AddStaticConstructor(conversionInfo);
+            }
         }
     }
 

--- a/Dntc.Common/Conversion/MethodConversionInfo.cs
+++ b/Dntc.Common/Conversion/MethodConversionInfo.cs
@@ -164,5 +164,6 @@ public class MethodConversionInfo
         IsPredeclared = false; // we need to write the custom code
         Header = method.HeaderName;
         NameInC = method.NativeName;
+        SourceFileName = method.SourceFileName;
     }
 }

--- a/Dntc.Common/Definitions/CustomDefinedMethod.cs
+++ b/Dntc.Common/Definitions/CustomDefinedMethod.cs
@@ -1,5 +1,4 @@
-﻿using Dntc.Common.Conversion;
-using Dntc.Common.Definitions.CustomDefinedMethods;
+﻿using Dntc.Common.Definitions.CustomDefinedMethods;
 using Dntc.Common.Syntax.Statements;
 
 namespace Dntc.Common.Definitions;
@@ -39,6 +38,7 @@ public abstract class CustomDefinedMethod : DefinedMethod
     public static IReadOnlyList<CustomDefinedMethod> StandardCustomMethods { get; } =
     [
         new FloatMinDefinedMethod(),
+        new StaticConstructorInitializerDefinedMethod(),
     ];
 
     protected override IReadOnlyList<IlTypeName> GetReferencedTypesInternal() => [];

--- a/Dntc.Common/Definitions/CustomDefinedMethods/StaticConstructorInitializerDefinedMethod.cs
+++ b/Dntc.Common/Definitions/CustomDefinedMethods/StaticConstructorInitializerDefinedMethod.cs
@@ -1,0 +1,42 @@
+﻿using System.Text;
+using Dntc.Common.Conversion;
+using Dntc.Common.Syntax.Statements;
+
+namespace Dntc.Common.Definitions.CustomDefinedMethods;
+
+public class StaticConstructorInitializerDefinedMethod : CustomDefinedMethod
+{
+    private const string Namespace = "Dntc.Utils";
+    private const string MethodName = "InitStaticConstructors";
+    private const string BaseFileName = "dntc_utils";
+    private const string FunctionName = "dntc_utils_init_static_constructors";
+    
+    private readonly List<MethodConversionInfo> _staticConstructors = [];
+    
+    public StaticConstructorInitializerDefinedMethod() 
+        : base(
+            new IlMethodId($"{Namespace}.{MethodName}()"), 
+            new IlTypeName(typeof(void).FullName!), 
+            new IlNamespace(Namespace), 
+            new HeaderName($"{BaseFileName}.h"), 
+            new CSourceFileName($"{BaseFileName}.c"), 
+            new CFunctionName(FunctionName), 
+            [])
+    {
+    }
+
+    public override CustomCodeStatementSet GetCustomDeclaration()
+    {
+        const string content = $"void {FunctionName}(void);";
+
+        return new CustomCodeStatementSet(content);
+    }
+
+    public override CustomCodeStatementSet GetCustomImplementation()
+    {
+        var content = new StringBuilder();
+        content.AppendLine($"void {FunctionName}(void) {{");
+        
+        
+    }
+}

--- a/Dntc.Common/Definitions/CustomDefinedMethods/StaticConstructorInitializerDefinedMethod.cs
+++ b/Dntc.Common/Definitions/CustomDefinedMethods/StaticConstructorInitializerDefinedMethod.cs
@@ -10,12 +10,14 @@ public class StaticConstructorInitializerDefinedMethod : CustomDefinedMethod
     private const string MethodName = "InitStaticConstructors";
     private const string BaseFileName = "dntc_utils";
     private const string FunctionName = "dntc_utils_init_static_constructors";
+
+    public static IlMethodId MethodId = new($"{Namespace}.{MethodName}()");
     
     private readonly List<MethodConversionInfo> _staticConstructors = [];
     
     public StaticConstructorInitializerDefinedMethod() 
         : base(
-            new IlMethodId($"{Namespace}.{MethodName}()"), 
+            MethodId,
             new IlTypeName(typeof(void).FullName!), 
             new IlNamespace(Namespace), 
             new HeaderName($"{BaseFileName}.h"), 
@@ -24,19 +26,44 @@ public class StaticConstructorInitializerDefinedMethod : CustomDefinedMethod
             [])
     {
     }
-
+    
     public override CustomCodeStatementSet GetCustomDeclaration()
     {
-        const string content = $"void {FunctionName}(void);";
+        var headers = _staticConstructors.Select(x => x.Header)
+            .Where(x => x != null)
+            .Distinct()
+            .OrderBy(x => x!.Value)
+            .ToArray();
 
-        return new CustomCodeStatementSet(content);
+        var content = new StringBuilder();
+        foreach (var header in headers)
+        {
+            content.AppendLine($"#include \"{header}\"");
+        }
+
+        content.AppendLine();
+        content.AppendLine($"void {FunctionName}(void);");
+
+        return new CustomCodeStatementSet(content.ToString());
     }
 
     public override CustomCodeStatementSet GetCustomImplementation()
     {
         var content = new StringBuilder();
         content.AppendLine($"void {FunctionName}(void) {{");
+
+        foreach (var constructor in _staticConstructors)
+        {
+            content.AppendLine($"\t{constructor.NameInC}();");
+        }
         
-        
+        content.AppendLine("}");
+
+        return new CustomCodeStatementSet(content.ToString());
+    }
+
+    public void AddStaticConstructor(MethodConversionInfo method)
+    {
+        _staticConstructors.Add(method);
     }
 }

--- a/Dntc.Common/Definitions/DefinedMethod.cs
+++ b/Dntc.Common/Definitions/DefinedMethod.cs
@@ -14,6 +14,12 @@ public abstract class DefinedMethod
     public IReadOnlyList<Parameter> Parameters { get; protected set; } = ArraySegment<Parameter>.Empty;
     public IReadOnlyList<Local> Locals { get; protected set; } = ArraySegment<Local>.Empty;
     
+    /// <summary>
+    /// Headers that are referenced by this method but cannot be inferred from static analysis. This is
+    /// mostly required for custom defined types.
+    /// </summary>
+    public IReadOnlyList<HeaderName> ManuallyReferencedHeaders { get; protected set; } = ArraySegment<HeaderName>.Empty;
+    
     public IReadOnlyList<IlTypeName> GetReferencedTypes => Locals.Select(x => x.Type)
         .Concat(Parameters.Select(x => x.Type))
         .Concat([ReturnType])

--- a/Dntc.Common/Planning/ImplementationPlan.cs
+++ b/Dntc.Common/Planning/ImplementationPlan.cs
@@ -183,4 +183,28 @@ public class ImplementationPlan
         AddReferencedHeaders(node, sourceFile);
         sourceFile.AddMethod(method);
     }
+
+    private void AddStaticConstructor(DependencyGraph.MethodNode node)
+    {
+        if (!node.MethodId.Value.EndsWith(".cctor()"))
+        {
+            // Not a static constructor
+            return;
+        }
+
+        var method = _conversionCatalog.Find(node.MethodId);
+        const string baseName = "dntc_utils";
+        var headerName = new HeaderName($"{baseName}.h");
+        var sourceFileName = new CSourceFileName($"{baseName}.h");
+
+        if (!_headers.TryGetValue(headerName, out var headerFile))
+        {
+            headerFile = new PlannedHeaderFile(headerName);
+            _headers.Add(headerName, headerFile);
+        }
+        
+        if (method.Header != null)
+        {
+        }
+    }
 }

--- a/Dntc.Common/Planning/ImplementationPlan.cs
+++ b/Dntc.Common/Planning/ImplementationPlan.cs
@@ -1,4 +1,5 @@
 ﻿using Dntc.Common.Conversion;
+using Dntc.Common.Definitions;
 using Dntc.Common.Definitions.CustomDefinedMethods;
 using Dntc.Common.Dependencies;
 
@@ -10,6 +11,7 @@ namespace Dntc.Common.Planning;
 public class ImplementationPlan
 {
     private readonly ConversionCatalog _conversionCatalog;
+    private readonly DefinitionCatalog _definitionCatalog;
     private readonly Dictionary<HeaderName, PlannedHeaderFile> _headers = new();
     private readonly Dictionary<CSourceFileName, PlannedSourceFile> _sourceFiles = new();
     private bool _staticConstructorInitializerAdded = false;
@@ -17,9 +19,10 @@ public class ImplementationPlan
     public IEnumerable<PlannedHeaderFile> Headers => _headers.Values;
     public IEnumerable<PlannedSourceFile> SourceFiles => _sourceFiles.Values;
 
-    public ImplementationPlan(ConversionCatalog conversionCatalog)
+    public ImplementationPlan(ConversionCatalog conversionCatalog, DefinitionCatalog definitionCatalog)
     {
         _conversionCatalog = conversionCatalog;
+        _definitionCatalog = definitionCatalog;
     }
 
     public void AddMethodGraph(DependencyGraph graph)
@@ -186,6 +189,12 @@ public class ImplementationPlan
         {
             sourceFile = new PlannedSourceFile(method.SourceFileName.Value);
             _sourceFiles[sourceFile.Name] = sourceFile;
+        }
+
+        var methodDefinition = _definitionCatalog.Get(node.MethodId);
+        foreach (var referencedHeader in methodDefinition!.ManuallyReferencedHeaders)
+        {
+            sourceFile.AddReferencedHeader(referencedHeader);
         }
         
         AddReferencedHeaders(node, sourceFile);

--- a/Dntc.Common/Planning/PlannedSourceFile.cs
+++ b/Dntc.Common/Planning/PlannedSourceFile.cs
@@ -7,12 +7,14 @@ public class PlannedSourceFile
     private readonly List<MethodConversionInfo> _implementedMethods = [];
     private readonly List<HeaderName> _referencedHeaders = [];
     private readonly List<TypeConversionInfo> _typesWithGlobals = [];
+    private readonly List<MethodConversionInfo> _staticConstructors = [];
     
     public CSourceFileName Name { get; }
 
     public IReadOnlyList<MethodConversionInfo> ImplementedMethods => _implementedMethods;
     public IReadOnlyList<HeaderName> ReferencedHeaders => _referencedHeaders;
     public IReadOnlyList<TypeConversionInfo> TypesWithGlobals => _typesWithGlobals;
+    public IReadOnlyList<MethodConversionInfo> StaticConstructors => _staticConstructors;
 
     public PlannedSourceFile(CSourceFileName name)
     {
@@ -45,6 +47,19 @@ public class PlannedSourceFile
         if (!_typesWithGlobals.Contains(type))
         {
             _typesWithGlobals.Add(type);
+        }
+    }
+
+    public void AddStaticConstructor(MethodConversionInfo constructor)
+    {
+        if (!_staticConstructors.Contains(constructor))
+        {
+            if (constructor.Header != null)
+            {
+                AddReferencedHeader(constructor.Header.Value);
+            }
+
+            _staticConstructors.Add(constructor);
         }
     }
 }

--- a/Dntc.Common/Planning/PlannedSourceFile.cs
+++ b/Dntc.Common/Planning/PlannedSourceFile.cs
@@ -49,17 +49,4 @@ public class PlannedSourceFile
             _typesWithGlobals.Add(type);
         }
     }
-
-    public void AddStaticConstructor(MethodConversionInfo constructor)
-    {
-        if (!_staticConstructors.Contains(constructor))
-        {
-            if (constructor.Header != null)
-            {
-                AddReferencedHeader(constructor.Header.Value);
-            }
-
-            _staticConstructors.Add(constructor);
-        }
-    }
 }

--- a/Dntc.Common/Syntax/Statements/CustomCodeStatementSet.cs
+++ b/Dntc.Common/Syntax/Statements/CustomCodeStatementSet.cs
@@ -7,6 +7,6 @@ public record CustomCodeStatementSet(string RawCode) : CStatementSet
 {
     public override async Task WriteAsync(StreamWriter writer)
     {
-        await writer.WriteLineAsync(RawCode);
+        await writer.WriteAsync(RawCode);
     }
 }

--- a/Samples/Scratchpad/scratchpad_c/generated/dntc_utils.c
+++ b/Samples/Scratchpad/scratchpad_c/generated/dntc_utils.c
@@ -1,14 +1,10 @@
 #include "dntc_utils.h"
-
-
 #include "ScratchpadCSharp.h"
 
-void dntc_utils_init_static_constructors(void);
 
+void dntc_utils_init_static_constructors(void)
  {
-void dntc_utils_init_static_constructors(void) {
 	ScratchpadCSharp_SimpleFunctions__cctor();
-}
 
 }
 

--- a/Samples/Scratchpad/scratchpad_c/generated/dntc_utils.c
+++ b/Samples/Scratchpad/scratchpad_c/generated/dntc_utils.c
@@ -1,0 +1,14 @@
+#include "dntc_utils.h"
+
+
+#include "ScratchpadCSharp.h"
+
+void dntc_utils_init_static_constructors(void);
+
+ {
+void dntc_utils_init_static_constructors(void) {
+	ScratchpadCSharp_SimpleFunctions__cctor();
+}
+
+}
+

--- a/Samples/Scratchpad/scratchpad_c/generated/dntc_utils.c
+++ b/Samples/Scratchpad/scratchpad_c/generated/dntc_utils.c
@@ -2,9 +2,7 @@
 #include "ScratchpadCSharp.h"
 
 
-void dntc_utils_init_static_constructors(void)
- {
+void dntc_utils_init_static_constructors(void) {
 	ScratchpadCSharp_SimpleFunctions__cctor();
-
 }
 

--- a/Samples/Scratchpad/scratchpad_c/generated/dntc_utils.h
+++ b/Samples/Scratchpad/scratchpad_c/generated/dntc_utils.h
@@ -1,0 +1,14 @@
+#ifndef DNTC_UTILS_H_H
+#define DNTC_UTILS_H_H
+
+
+
+
+
+#include "ScratchpadCSharp.h"
+
+void dntc_utils_init_static_constructors(void);
+
+;
+
+#endif // DNTC_UTILS_H_H

--- a/Samples/Scratchpad/scratchpad_c/generated/dntc_utils.h
+++ b/Samples/Scratchpad/scratchpad_c/generated/dntc_utils.h
@@ -5,10 +5,7 @@
 
 
 
-#include "ScratchpadCSharp.h"
-
-void dntc_utils_init_static_constructors(void);
-
+void dntc_utils_init_static_constructors(void)
 ;
 
 #endif // DNTC_UTILS_H_H

--- a/Samples/Scratchpad/scratchpad_c/generated/dntc_utils.h
+++ b/Samples/Scratchpad/scratchpad_c/generated/dntc_utils.h
@@ -5,7 +5,6 @@
 
 
 
-void dntc_utils_init_static_constructors(void)
-;
+void dntc_utils_init_static_constructors(void);
 
 #endif // DNTC_UTILS_H_H

--- a/Samples/Scratchpad/scratchpad_c/generated/dotnet_arrays.h
+++ b/Samples/Scratchpad/scratchpad_c/generated/dotnet_arrays.h
@@ -12,5 +12,4 @@ typedef struct {
 
 
 
-
 #endif // DOTNET_ARRAYS_H_H

--- a/Samples/Scratchpad/scratchpad_c/main.c
+++ b/Samples/Scratchpad/scratchpad_c/main.c
@@ -2,10 +2,13 @@
 #include <stdio.h>
 #include "generated/fn_pointer_types.h"
 #include "generated/ScratchpadCSharp.h"
+#include "generated/dntc_utils.h"
 
 #define ARRAY_ITEM_COUNT (10)
 
 int main(void) {
+    dntc_utils_init_static_constructors();
+
     ScratchpadCSharp_SimpleFunctions_Vector3 first = {.X = 1, .Y = 2, .Z = 3};
     ScratchpadCSharp_SimpleFunctions_Vector3 second = {.X = 4, .Y = 5, .Z = 6};
     ScratchpadCSharp_SimpleFunctions_Vector3 result = ScratchpadCSharp_SimpleFunctions_StructOpOverload(first, second);
@@ -71,7 +74,6 @@ int main(void) {
     staticTest1 = ScratchpadCSharp_SimpleFunctions_IncrementStaticInt();
     assert(staticTest1 == 7);
 
-    ScratchpadCSharp_SimpleFunctions__cctor();
     ScratchpadCSharp_SimpleFunctions_Vector3 staticVector = ScratchpadCSharp_SimpleFunctions_GetStaticVector();
     assert(staticVector.X == 10);
     assert(staticVector.Y == 11);


### PR DESCRIPTION
Since we don't have a runtime that can manage static constructors ourselves, the hosting C99 code must initialize static constructors manually.  

To make this easy, a `dntc_utils_init_static_constructors()` function is now code generated when static constructors are transpiled.  The hosting C99 code can now call this to deterministically invoke all static constructors for transpiled code.