### PR TITLE
Native globals on transpile

### DIFF
--- a/Dntc.Attributes/NativeGlobalOnTranspileAttribute.cs
+++ b/Dntc.Attributes/NativeGlobalOnTranspileAttribute.cs
@@ -1,8 +1,8 @@
 namespace Dntc.Attributes;
 
 /// <summary>
-/// Specifies that references to the field or property this attribute is attached to should instead
-/// reference a native global when transpiled.
+/// Specifies that references to the field this attribute is attached to should reference a native
+/// global when transpiled.
 /// </summary>
 /// <param name="globalName">
 /// The name of the global in C that will be referenced after transpilation process.
@@ -10,7 +10,7 @@ namespace Dntc.Attributes;
 /// <param name="headerName">
 /// The header that needs to be referenced to access the global
 /// </param>
-[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+[AttributeUsage(AttributeTargets.Field)]
 public class NativeGlobalOnTranspileAttribute(string globalName, string? headerName) : Attribute
 {
     public string GlobalName => globalName;

--- a/Dntc.Attributes/NativeGlobalOnTranspileAttribute.cs
+++ b/Dntc.Attributes/NativeGlobalOnTranspileAttribute.cs
@@ -1,0 +1,18 @@
+namespace Dntc.Attributes;
+
+/// <summary>
+/// Specifies that references to the field or property this attribute is attached to should instead
+/// reference a native global when transpiled.
+/// </summary>
+/// <param name="globalName">
+/// The name of the global in C that will be referenced after transpilation process.
+/// </param>
+/// <param name="headerName">
+/// The header that needs to be referenced to access the global
+/// </param>
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+public class NativeGlobalOnTranspileAttribute(string globalName, string? headerName) : Attribute
+{
+    public string GlobalName => globalName;
+    public string? HeaderName => headerName;
+}

--- a/Dntc.Common/Conversion/PlannedFileConverter.cs
+++ b/Dntc.Common/Conversion/PlannedFileConverter.cs
@@ -45,6 +45,7 @@ public class PlannedFileConverter
             .Where(x => x != null)
             .SelectMany(x => x!.Fields
                 .Where(y => y.isStatic)
+                .Where(y => !y.IsNativelyDefined)
                 .Select(y => new GlobalVariableDeclaration(x, y, _conversionCatalog, true)))
             .ToArray();
 
@@ -72,6 +73,7 @@ public class PlannedFileConverter
             .Where(x => x != null)
             .SelectMany(x => x!.Fields
                 .Where(y => y.isStatic)
+                .Where(y => !y.IsNativelyDefined)
                 .Select(y => new GlobalVariableDeclaration(x, y, _conversionCatalog, false)))
             .ToArray();
 

--- a/Dntc.Common/Definitions/CustomDefinedMethods/StaticConstructorInitializerDefinedMethod.cs
+++ b/Dntc.Common/Definitions/CustomDefinedMethods/StaticConstructorInitializerDefinedMethod.cs
@@ -51,7 +51,7 @@ public class StaticConstructorInitializerDefinedMethod : CustomDefinedMethod
         if (method.Header != null)
         {
             _referencedHeaders.Add(method.Header.Value);
-            ManuallyReferencedHeaders = _referencedHeaders.OrderBy(x => x.Value).ToArray();
+            ReferencedHeaders = _referencedHeaders.OrderBy(x => x.Value).ToArray();
         }
     }
 }

--- a/Dntc.Common/Definitions/DefinedMethod.cs
+++ b/Dntc.Common/Definitions/DefinedMethod.cs
@@ -13,8 +13,8 @@ public abstract class DefinedMethod
     public IReadOnlyList<Local> Locals { get; protected set; } = ArraySegment<Local>.Empty;
     
     /// <summary>
-    /// Headers that are referenced by this method but cannot be inferred from static analysis. This is
-    /// mostly required for custom defined types.
+    /// Headers that are referenced by this method but cannot be inferred from initial static analysis. This is
+    /// mostly required for custom defined types, or headers due to customizations found during method analysis..
     /// </summary>
     public IReadOnlyList<HeaderName> ReferencedHeaders { get; protected set; } = ArraySegment<HeaderName>.Empty;
     

--- a/Dntc.Common/Definitions/DefinedMethod.cs
+++ b/Dntc.Common/Definitions/DefinedMethod.cs
@@ -1,6 +1,4 @@
-﻿using Mono.Cecil;
-
-namespace Dntc.Common.Definitions;
+﻿namespace Dntc.Common.Definitions;
 
 public abstract class DefinedMethod
 {
@@ -18,7 +16,7 @@ public abstract class DefinedMethod
     /// Headers that are referenced by this method but cannot be inferred from static analysis. This is
     /// mostly required for custom defined types.
     /// </summary>
-    public IReadOnlyList<HeaderName> ManuallyReferencedHeaders { get; protected set; } = ArraySegment<HeaderName>.Empty;
+    public IReadOnlyList<HeaderName> ReferencedHeaders { get; protected set; } = ArraySegment<HeaderName>.Empty;
     
     public IReadOnlyList<IlTypeName> GetReferencedTypes => Locals.Select(x => x.Type)
         .Concat(Parameters.Select(x => x.Type))

--- a/Dntc.Common/Definitions/DefinedType.cs
+++ b/Dntc.Common/Definitions/DefinedType.cs
@@ -2,7 +2,7 @@
 
 public abstract class DefinedType
 {
-    public record Field(IlTypeName Type, string Name, bool isStatic);
+    public record Field(IlTypeName Type, string Name, bool isStatic, bool IsNativelyDefined);
     
     public IlTypeName IlName { get; protected set; }
     

--- a/Dntc.Common/Definitions/DotNetDefinedMethod.cs
+++ b/Dntc.Common/Definitions/DotNetDefinedMethod.cs
@@ -165,7 +165,8 @@ public class DotNetDefinedMethod : DefinedMethod
         {
             return;
         }
-        
+
+        var referencedHeaders = new HashSet<HeaderName>();
         foreach (var instruction in Definition.Body.Instructions)
         {
             if (!KnownOpCodeHandlers.OpCodeHandlers.TryGetValue(instruction.OpCode.Code, out var handler))
@@ -189,8 +190,14 @@ public class DotNetDefinedMethod : DefinedMethod
             {
                 _typesRequiringStaticConstruction.Add(type);
             }
+
+            foreach (var header in results.ReferencedHeaders)
+            {
+                referencedHeaders.Add(header);
+            }
         }
 
+        ReferencedHeaders = ReferencedHeaders.Union(referencedHeaders).ToArray();
         _hasBeenAnalyzed = true;
     }
 }

--- a/Dntc.Common/Definitions/DotNetDefinedType.cs
+++ b/Dntc.Common/Definitions/DotNetDefinedType.cs
@@ -1,4 +1,5 @@
-﻿using Mono.Cecil;
+﻿using Dntc.Common.OpCodeHandling;
+using Mono.Cecil;
 
 namespace Dntc.Common.Definitions;
 
@@ -24,13 +25,21 @@ public class DotNetDefinedType : DefinedType
         Namespace = new IlNamespace(rootDeclaringType.Namespace);
 
         Fields = definition.Fields
-            .Select(x => new Field(new IlTypeName(x.FieldType.FullName), x.Name, x.IsStatic))
+            .Select(ConvertToField)
             .ToArray();
 
         Methods = definition.Methods
             .Select(x => new IlMethodId(x.FullName))
             .ToArray();
-        
-        
+    }
+
+    private static Field ConvertToField(FieldDefinition fieldDefinition)
+    {
+        var type = new IlTypeName(fieldDefinition.FieldType.FullName);
+        var name = fieldDefinition.Name;
+        var isStatic = fieldDefinition.IsStatic;
+        var nativeGlobalInfo = NativeGlobalOnTranspileInfo.FromAttributes(fieldDefinition.CustomAttributes, type.Value);
+
+        return new Field(type, name, isStatic, nativeGlobalInfo != null);
     }
 }

--- a/Dntc.Common/OpCodeHandling/Handlers/CallHandlers.cs
+++ b/Dntc.Common/OpCodeHandling/Handlers/CallHandlers.cs
@@ -63,54 +63,11 @@ public class CallHandlers : IOpCodeHandlerCollection
         context.ExpressionStack.Push(expression);
         return new OpCodeHandlingResult(null);
     }
-
-    private static NativeGlobalOnTranspileInfo? GetNativeGlobalOnTranspileInfo(object operand)
-    {
-        if (operand is not MethodDefinition definition)
-        {
-            return null;
-        }
-        
-        // TODO: find the backing field and pull attribute off of that???
-        throw 
-    }
     
     private class CallHandler : IOpCodeHandler
     {
         public OpCodeHandlingResult Handle(HandleContext context)
         {
-            var nativeGlobalInfo = GetNativeGlobalOnTranspileInfo(context.CurrentInstruction.Operand);
-            if (nativeGlobalInfo != null)
-            {
-                // This is either a getter or a setter for a global. We know based on its return type.
-                var methodDefinition = (MethodDefinition)context.CurrentInstruction.Operand;
-                var conversionInfo = context.ConversionCatalog.Find(new IlMethodId(methodDefinition.FullName));
-                if (methodDefinition.IsSetter)
-                {
-                    var items = context.ExpressionStack.Pop(1);
-                    var value = items[0];
-
-                    var fieldType = conversionInfo.Parameters[0].ConversionInfo;
-                    var left = new VariableValueExpression(new Variable(fieldType, nativeGlobalInfo.NativeName, false));
-                    var right = new DereferencedValueExpression(value);
-                    var statement = new AssignmentStatementSet(left, right);
-
-                    return new OpCodeHandlingResult(statement);
-                }
-
-                if (methodDefinition.IsGetter)
-                {
-                    var variable = new Variable(conversionInfo.ReturnTypeInfo, nativeGlobalInfo.NativeName, false);
-                    context.ExpressionStack.Push(new VariableValueExpression(variable));
-                    return new OpCodeHandlingResult(null);
-                }
-
-                var message = $"{methodDefinition.FullName} had a NativeGlobalOnTranspileInfo attribute on it, but " +
-                              $"it was not a getter or setter. Globals are not methods so this is not expected.";
-
-                throw new InvalidOperationException(message);
-            }
-            
             var methodReference = (MethodReference)context.CurrentInstruction.Operand;
             var methodId = new IlMethodId(methodReference.FullName);
             return CallMethodReference(context, methodId, new IlTypeName(methodReference.ReturnType.FullName));
@@ -118,19 +75,6 @@ public class CallHandlers : IOpCodeHandlerCollection
 
         public OpCodeAnalysisResult Analyze(AnalyzeContext context)
         {
-            var nativeGlobalInfo = GetNativeGlobalOnTranspileInfo(context.CurrentInstruction.Operand);
-            if (nativeGlobalInfo != null)
-            {
-                HashSet<HeaderName> headers = nativeGlobalInfo.HeaderName != null
-                    ? [nativeGlobalInfo.HeaderName.Value]
-                    : [];
-
-                return new OpCodeAnalysisResult
-                {
-                    ReferencedHeaders = new HashSet<HeaderName>(headers),
-                };
-            }
-            
             return new OpCodeAnalysisResult
             {
                 CalledMethod = GetCallTarget(context.CurrentInstruction, context.CurrentMethod),

--- a/Dntc.Common/OpCodeHandling/NativeGlobalOnTranspileInfo.cs
+++ b/Dntc.Common/OpCodeHandling/NativeGlobalOnTranspileInfo.cs
@@ -35,8 +35,8 @@ public record NativeGlobalOnTranspileInfo
             throw new InvalidOperationException(message);
         }
 
-        var nativeName = attribute.ConstructorArguments[0].ToString();
-        var header = attribute.ConstructorArguments[1].ToString();
+        var nativeName = attribute.ConstructorArguments[0].Value.ToString();
+        var header = attribute.ConstructorArguments[1].Value.ToString();
         
         if (nativeName == null)
         {

--- a/Dntc.Common/OpCodeHandling/NativeGlobalOnTranspileInfo.cs
+++ b/Dntc.Common/OpCodeHandling/NativeGlobalOnTranspileInfo.cs
@@ -8,7 +8,7 @@ public record NativeGlobalOnTranspileInfo
     public string NativeName { get; }
     public HeaderName? HeaderName { get; }
 
-    public NativeGlobalOnTranspileInfo(string nativeName, string? headerName)
+    private NativeGlobalOnTranspileInfo(string nativeName, string? headerName)
     {
         NativeName = nativeName;
         HeaderName = headerName != null ? new HeaderName(headerName) : null;

--- a/Dntc.Common/OpCodeHandling/NativeGlobalOnTranspileInfo.cs
+++ b/Dntc.Common/OpCodeHandling/NativeGlobalOnTranspileInfo.cs
@@ -1,0 +1,49 @@
+using Dntc.Attributes;
+using Mono.Cecil;
+
+namespace Dntc.Common.OpCodeHandling;
+
+public record NativeGlobalOnTranspileInfo
+{
+    public string NativeName { get; }
+    public HeaderName? HeaderName { get; }
+
+    public NativeGlobalOnTranspileInfo(string nativeName, string? headerName)
+    {
+        NativeName = nativeName;
+        HeaderName = headerName != null ? new HeaderName(headerName) : null;
+    }
+
+    public static NativeGlobalOnTranspileInfo? FromAttributes(
+        IEnumerable<CustomAttribute> customAttributes, 
+        string fieldName)
+    {
+        var attribute = customAttributes
+            .SingleOrDefault(x => x.AttributeType.FullName == typeof(NativeGlobalOnTranspileAttribute).FullName);
+
+        if (attribute == null)
+        {
+            return null;
+        }
+
+        if (attribute.ConstructorArguments.Count != 2)
+        {
+            var message =
+                $"Expected {fieldName}'s {typeof(NativeGlobalOnTranspileAttribute).FullName}'s " +
+                $"specification 2 have 2 arguments, but only 1 was present";
+
+            throw new InvalidOperationException(message);
+        }
+
+        var nativeName = attribute.ConstructorArguments[0].ToString();
+        var header = attribute.ConstructorArguments[1].ToString();
+        
+        if (nativeName == null)
+        {
+            var message = $"{fieldName}'s {typeof(NativeGlobalOnTranspileAttribute).FullName}'s had a null native name";
+            throw new InvalidOperationException(message);
+        }
+
+        return new NativeGlobalOnTranspileInfo(nativeName, header);
+    }
+}

--- a/Dntc.Common/OpCodeHandling/OpCodeAnalysisResult.cs
+++ b/Dntc.Common/OpCodeHandling/OpCodeAnalysisResult.cs
@@ -5,4 +5,5 @@ public class OpCodeAnalysisResult
     public InvokedMethod? CalledMethod { get; init; }
     public IReadOnlySet<IlTypeName> ReferencedTypes { get; init; } = new HashSet<IlTypeName>();
     public IReadOnlySet<IlTypeName> TypesRequiringStaticConstruction { get; init; } = new HashSet<IlTypeName>();
+    public IReadOnlySet<HeaderName> ReferencedHeaders { get; init; } = new HashSet<HeaderName>();
 }

--- a/Dntc.Common/Planning/ImplementationPlan.cs
+++ b/Dntc.Common/Planning/ImplementationPlan.cs
@@ -199,7 +199,7 @@ public class ImplementationPlan
         }
 
         var methodDefinition = _definitionCatalog.Get(node.MethodId);
-        foreach (var referencedHeader in methodDefinition!.ManuallyReferencedHeaders)
+        foreach (var referencedHeader in methodDefinition!.ReferencedHeaders)
         {
             sourceFile.AddReferencedHeader(referencedHeader);
         }

--- a/Samples/Scratchpad/ScratchpadCSharp/AttributeTests.cs
+++ b/Samples/Scratchpad/ScratchpadCSharp/AttributeTests.cs
@@ -27,4 +27,9 @@ public static class AttributeTests
     {
         return StaticNumberProperty;
     }
+
+    public static void SetStaticNumberField(uint num)
+    {
+        StaticNumberField = num;
+    }
 }

--- a/Samples/Scratchpad/ScratchpadCSharp/AttributeTests.cs
+++ b/Samples/Scratchpad/ScratchpadCSharp/AttributeTests.cs
@@ -11,4 +11,20 @@ public static class AttributeTests
     {
         return 99;
     }
+
+    [NativeGlobalOnTranspile("static_number", "../native_test.h")]
+    public static uint StaticNumberField;
+    
+    [NativeGlobalOnTranspile("static_number", "../native_test.h")]
+    public static uint StaticNumberProperty { get; set; }
+
+    public static uint GetStaticNumberField()
+    {
+        return StaticNumberField;
+    }
+
+    public static uint GetStaticNumberProperty()
+    {
+        return StaticNumberProperty;
+    }
 }

--- a/Samples/Scratchpad/ScratchpadCSharp/AttributeTests.cs
+++ b/Samples/Scratchpad/ScratchpadCSharp/AttributeTests.cs
@@ -15,17 +15,9 @@ public static class AttributeTests
     [NativeGlobalOnTranspile("static_number", "../native_test.h")]
     public static uint StaticNumberField;
     
-    [NativeGlobalOnTranspile("static_number", "../native_test.h")]
-    public static uint StaticNumberProperty { get; set; }
-
     public static uint GetStaticNumberField()
     {
         return StaticNumberField;
-    }
-
-    public static uint GetStaticNumberProperty()
-    {
-        return StaticNumberProperty;
     }
 
     public static void SetStaticNumberField(uint num)

--- a/Samples/Scratchpad/scratchpad-debug.json
+++ b/Samples/Scratchpad/scratchpad-debug.json
@@ -34,8 +34,7 @@
     "System.Int32 ScratchpadCSharp.SimpleFunctions::IncrementStaticInt()",
     "ScratchpadCSharp.SimpleFunctions/Vector3 ScratchpadCSharp.SimpleFunctions::GetStaticVector()",
     "System.UInt32 ScratchpadCSharp.AttributeTests::GetStaticNumberField()",
-    "System.Void ScratchpadCSharp.AttributeTests::SetStaticNumberField(System.UInt32)",
-    "System.UInt32 ScratchpadCSharp.AttributeTests::GetStaticNumberProperty()"
+    "System.Void ScratchpadCSharp.AttributeTests::SetStaticNumberField(System.UInt32)"
   ],
   "OutputDirectory": "scratchpad_c/generated"
 }

--- a/Samples/Scratchpad/scratchpad-debug.json
+++ b/Samples/Scratchpad/scratchpad-debug.json
@@ -32,7 +32,9 @@
     "System.Int32 ScratchpadCSharp.GenericTests::GetStaticNumber(System.Int32)",
     "System.UInt32 ScratchpadCSharp.AttributeTests::GetNumberMethod()",
     "System.Int32 ScratchpadCSharp.SimpleFunctions::IncrementStaticInt()",
-    "ScratchpadCSharp.SimpleFunctions/Vector3 ScratchpadCSharp.SimpleFunctions::GetStaticVector()"
+    "ScratchpadCSharp.SimpleFunctions/Vector3 ScratchpadCSharp.SimpleFunctions::GetStaticVector()",
+    "System.UInt32 ScratchpadCSharp.AttributeTests::GetStaticNumberField()",
+    "System.UInt32 ScratchpadCSharp.AttributeTests::GetStaticNumberProperty()"
   ],
   "OutputDirectory": "scratchpad_c/generated"
 }

--- a/Samples/Scratchpad/scratchpad-debug.json
+++ b/Samples/Scratchpad/scratchpad-debug.json
@@ -34,6 +34,7 @@
     "System.Int32 ScratchpadCSharp.SimpleFunctions::IncrementStaticInt()",
     "ScratchpadCSharp.SimpleFunctions/Vector3 ScratchpadCSharp.SimpleFunctions::GetStaticVector()",
     "System.UInt32 ScratchpadCSharp.AttributeTests::GetStaticNumberField()",
+    "System.Void ScratchpadCSharp.AttributeTests::SetStaticNumberField(System.UInt32)",
     "System.UInt32 ScratchpadCSharp.AttributeTests::GetStaticNumberProperty()"
   ],
   "OutputDirectory": "scratchpad_c/generated"

--- a/Samples/Scratchpad/scratchpad-release.json
+++ b/Samples/Scratchpad/scratchpad-release.json
@@ -34,8 +34,7 @@
     "System.Int32 ScratchpadCSharp.SimpleFunctions::IncrementStaticInt()",
     "ScratchpadCSharp.SimpleFunctions/Vector3 ScratchpadCSharp.SimpleFunctions::GetStaticVector()",
     "System.UInt32 ScratchpadCSharp.AttributeTests::GetStaticNumberField()",
-    "System.Void ScratchpadCSharp.AttributeTests::SetStaticNumberField(System.UInt32)",
-    "System.UInt32 ScratchpadCSharp.AttributeTests::GetStaticNumberProperty()"
+    "System.Void ScratchpadCSharp.AttributeTests::SetStaticNumberField(System.UInt32)"
   ],
   "OutputDirectory": "scratchpad_c/generated"
 }

--- a/Samples/Scratchpad/scratchpad-release.json
+++ b/Samples/Scratchpad/scratchpad-release.json
@@ -32,7 +32,9 @@
     "System.Int32 ScratchpadCSharp.GenericTests::GetStaticNumber(System.Int32)",
     "System.UInt32 ScratchpadCSharp.AttributeTests::GetNumberMethod()",
     "System.Int32 ScratchpadCSharp.SimpleFunctions::IncrementStaticInt()",
-    "ScratchpadCSharp.SimpleFunctions/Vector3 ScratchpadCSharp.SimpleFunctions::GetStaticVector()"
+    "ScratchpadCSharp.SimpleFunctions/Vector3 ScratchpadCSharp.SimpleFunctions::GetStaticVector()",
+    "System.UInt32 ScratchpadCSharp.AttributeTests::GetStaticNumberField()",
+    "System.UInt32 ScratchpadCSharp.AttributeTests::GetStaticNumberProperty()"
   ],
   "OutputDirectory": "scratchpad_c/generated"
 }

--- a/Samples/Scratchpad/scratchpad-release.json
+++ b/Samples/Scratchpad/scratchpad-release.json
@@ -34,6 +34,7 @@
     "System.Int32 ScratchpadCSharp.SimpleFunctions::IncrementStaticInt()",
     "ScratchpadCSharp.SimpleFunctions/Vector3 ScratchpadCSharp.SimpleFunctions::GetStaticVector()",
     "System.UInt32 ScratchpadCSharp.AttributeTests::GetStaticNumberField()",
+    "System.Void ScratchpadCSharp.AttributeTests::SetStaticNumberField(System.UInt32)",
     "System.UInt32 ScratchpadCSharp.AttributeTests::GetStaticNumberProperty()"
   ],
   "OutputDirectory": "scratchpad_c/generated"

--- a/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.c
+++ b/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.c
@@ -271,6 +271,11 @@ uint32_t ScratchpadCSharp_AttributeTests_GetStaticNumberField() {
 	return static_number;
 }
 
+void ScratchpadCSharp_AttributeTests_SetStaticNumberField(uint32_t num) {
+	static_number = num;
+	return;
+}
+
 uint32_t ScratchpadCSharp_AttributeTests_get_StaticNumberProperty() {
 	return ScratchpadCSharp_AttributeTests__StaticNumberProperty_k__BackingField;
 }

--- a/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.c
+++ b/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.c
@@ -7,7 +7,6 @@
 
  int32_t ScratchpadCSharp_SimpleFunctions_SomeStaticInt;
  ScratchpadCSharp_SimpleFunctions_Vector3 ScratchpadCSharp_SimpleFunctions_AStaticVector;
- uint32_t ScratchpadCSharp_AttributeTests_StaticNumberField;
 
 int32_t ScratchpadCSharp_SimpleFunctions_BitwiseOps(int32_t a) {
 	return ((((a >> 1) | (a & 15)) << 2) ^ 255);

--- a/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.c
+++ b/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.c
@@ -8,7 +8,6 @@
  int32_t ScratchpadCSharp_SimpleFunctions_SomeStaticInt;
  ScratchpadCSharp_SimpleFunctions_Vector3 ScratchpadCSharp_SimpleFunctions_AStaticVector;
  uint32_t ScratchpadCSharp_AttributeTests_StaticNumberField;
- uint32_t ScratchpadCSharp_AttributeTests__StaticNumberProperty_k__BackingField;
 
 int32_t ScratchpadCSharp_SimpleFunctions_BitwiseOps(int32_t a) {
 	return ((((a >> 1) | (a & 15)) << 2) ^ 255);
@@ -274,13 +273,5 @@ uint32_t ScratchpadCSharp_AttributeTests_GetStaticNumberField() {
 void ScratchpadCSharp_AttributeTests_SetStaticNumberField(uint32_t num) {
 	static_number = num;
 	return;
-}
-
-uint32_t ScratchpadCSharp_AttributeTests_get_StaticNumberProperty() {
-	return ScratchpadCSharp_AttributeTests__StaticNumberProperty_k__BackingField;
-}
-
-uint32_t ScratchpadCSharp_AttributeTests_GetStaticNumberProperty() {
-	return ScratchpadCSharp_AttributeTests_get_StaticNumberProperty();
 }
 

--- a/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.c
+++ b/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.c
@@ -7,6 +7,8 @@
 
  int32_t ScratchpadCSharp_SimpleFunctions_SomeStaticInt;
  ScratchpadCSharp_SimpleFunctions_Vector3 ScratchpadCSharp_SimpleFunctions_AStaticVector;
+ uint32_t ScratchpadCSharp_AttributeTests_StaticNumberField;
+ uint32_t ScratchpadCSharp_AttributeTests__StaticNumberProperty_k__BackingField;
 
 int32_t ScratchpadCSharp_SimpleFunctions_BitwiseOps(int32_t a) {
 	return ((((a >> 1) | (a & 15)) << 2) ^ 255);
@@ -263,5 +265,17 @@ int32_t ScratchpadCSharp_SimpleFunctions_IncrementStaticInt() {
 
 ScratchpadCSharp_SimpleFunctions_Vector3 ScratchpadCSharp_SimpleFunctions_GetStaticVector() {
 	return ScratchpadCSharp_SimpleFunctions_AStaticVector;
+}
+
+uint32_t ScratchpadCSharp_AttributeTests_GetStaticNumberField() {
+	return static_number;
+}
+
+uint32_t ScratchpadCSharp_AttributeTests_get_StaticNumberProperty() {
+	return ScratchpadCSharp_AttributeTests__StaticNumberProperty_k__BackingField;
+}
+
+uint32_t ScratchpadCSharp_AttributeTests_GetStaticNumberProperty() {
+	return ScratchpadCSharp_AttributeTests_get_StaticNumberProperty();
 }
 

--- a/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.h
+++ b/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.h
@@ -40,9 +40,14 @@ typedef struct {
 typedef struct {
 } ScratchpadCSharp_SimpleFunctions;
 
+typedef struct {
+} ScratchpadCSharp_AttributeTests;
+
 
 extern int32_t ScratchpadCSharp_SimpleFunctions_SomeStaticInt;
 extern ScratchpadCSharp_SimpleFunctions_Vector3 ScratchpadCSharp_SimpleFunctions_AStaticVector;
+extern uint32_t ScratchpadCSharp_AttributeTests_StaticNumberField;
+extern uint32_t ScratchpadCSharp_AttributeTests__StaticNumberProperty_k__BackingField;
 
 int32_t ScratchpadCSharp_SimpleFunctions_BitwiseOps(int32_t a);
 int32_t ScratchpadCSharp_SimpleFunctions_FnPointerTest(FnPtr_Int32_Int32_Returns_Int32 fn, int32_t x, int32_t y);
@@ -79,5 +84,8 @@ uint32_t ScratchpadCSharp_AttributeTests_GetNumberMethod();
 void ScratchpadCSharp_SimpleFunctions__cctor();
 int32_t ScratchpadCSharp_SimpleFunctions_IncrementStaticInt();
 ScratchpadCSharp_SimpleFunctions_Vector3 ScratchpadCSharp_SimpleFunctions_GetStaticVector();
+uint32_t ScratchpadCSharp_AttributeTests_GetStaticNumberField();
+uint32_t ScratchpadCSharp_AttributeTests_get_StaticNumberProperty();
+uint32_t ScratchpadCSharp_AttributeTests_GetStaticNumberProperty();
 
 #endif // SCRATCHPADCSHARP_H_H

--- a/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.h
+++ b/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.h
@@ -85,6 +85,7 @@ void ScratchpadCSharp_SimpleFunctions__cctor();
 int32_t ScratchpadCSharp_SimpleFunctions_IncrementStaticInt();
 ScratchpadCSharp_SimpleFunctions_Vector3 ScratchpadCSharp_SimpleFunctions_GetStaticVector();
 uint32_t ScratchpadCSharp_AttributeTests_GetStaticNumberField();
+void ScratchpadCSharp_AttributeTests_SetStaticNumberField(uint32_t num);
 uint32_t ScratchpadCSharp_AttributeTests_get_StaticNumberProperty();
 uint32_t ScratchpadCSharp_AttributeTests_GetStaticNumberProperty();
 

--- a/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.h
+++ b/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.h
@@ -47,7 +47,6 @@ typedef struct {
 extern int32_t ScratchpadCSharp_SimpleFunctions_SomeStaticInt;
 extern ScratchpadCSharp_SimpleFunctions_Vector3 ScratchpadCSharp_SimpleFunctions_AStaticVector;
 extern uint32_t ScratchpadCSharp_AttributeTests_StaticNumberField;
-extern uint32_t ScratchpadCSharp_AttributeTests__StaticNumberProperty_k__BackingField;
 
 int32_t ScratchpadCSharp_SimpleFunctions_BitwiseOps(int32_t a);
 int32_t ScratchpadCSharp_SimpleFunctions_FnPointerTest(FnPtr_Int32_Int32_Returns_Int32 fn, int32_t x, int32_t y);
@@ -86,7 +85,5 @@ int32_t ScratchpadCSharp_SimpleFunctions_IncrementStaticInt();
 ScratchpadCSharp_SimpleFunctions_Vector3 ScratchpadCSharp_SimpleFunctions_GetStaticVector();
 uint32_t ScratchpadCSharp_AttributeTests_GetStaticNumberField();
 void ScratchpadCSharp_AttributeTests_SetStaticNumberField(uint32_t num);
-uint32_t ScratchpadCSharp_AttributeTests_get_StaticNumberProperty();
-uint32_t ScratchpadCSharp_AttributeTests_GetStaticNumberProperty();
 
 #endif // SCRATCHPADCSHARP_H_H

--- a/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.h
+++ b/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.h
@@ -46,7 +46,6 @@ typedef struct {
 
 extern int32_t ScratchpadCSharp_SimpleFunctions_SomeStaticInt;
 extern ScratchpadCSharp_SimpleFunctions_Vector3 ScratchpadCSharp_SimpleFunctions_AStaticVector;
-extern uint32_t ScratchpadCSharp_AttributeTests_StaticNumberField;
 
 int32_t ScratchpadCSharp_SimpleFunctions_BitwiseOps(int32_t a);
 int32_t ScratchpadCSharp_SimpleFunctions_FnPointerTest(FnPtr_Int32_Int32_Returns_Int32 fn, int32_t x, int32_t y);

--- a/Samples/Scratchpad/scratchpad_c/main.c
+++ b/Samples/Scratchpad/scratchpad_c/main.c
@@ -82,8 +82,8 @@ int main(void) {
     uint32_t staticNumber1 = ScratchpadCSharp_AttributeTests_GetStaticNumberField();
     assert(staticNumber1 == 55);
 
-    uint32_t staticNumber2 = ScratchpadCSharp_AttributeTests_GetStaticNumberProperty();
-    assert(staticNumber2 == 55);
+    ScratchpadCSharp_AttributeTests_SetStaticNumberField(23);
+    assert(static_number == 23);
 
     printf("Tests passed!\n");
     return 0;

--- a/Samples/Scratchpad/scratchpad_c/main.c
+++ b/Samples/Scratchpad/scratchpad_c/main.c
@@ -79,6 +79,12 @@ int main(void) {
     assert(staticVector.Y == 11);
     assert(staticVector.Z == 12);
 
+    uint32_t staticNumber1 = ScratchpadCSharp_AttributeTests_GetStaticNumberField();
+    assert(staticNumber1 == 55);
+
+    uint32_t staticNumber2 = ScratchpadCSharp_AttributeTests_GetStaticNumberProperty();
+    assert(staticNumber2 == 55);
+
     printf("Tests passed!\n");
     return 0;
 }

--- a/Samples/Scratchpad/scratchpad_c/main.c
+++ b/Samples/Scratchpad/scratchpad_c/main.c
@@ -85,6 +85,9 @@ int main(void) {
     ScratchpadCSharp_AttributeTests_SetStaticNumberField(23);
     assert(static_number == 23);
 
+    uint32_t staticNumber3 = ScratchpadCSharp_AttributeTests_GetStaticNumberProperty();
+    assert(staticNumber3 == 23);
+
     printf("Tests passed!\n");
     return 0;
 }

--- a/Samples/Scratchpad/scratchpad_c/main.c
+++ b/Samples/Scratchpad/scratchpad_c/main.c
@@ -85,9 +85,6 @@ int main(void) {
     ScratchpadCSharp_AttributeTests_SetStaticNumberField(23);
     assert(static_number == 23);
 
-    uint32_t staticNumber3 = ScratchpadCSharp_AttributeTests_GetStaticNumberProperty();
-    assert(staticNumber3 == 23);
-
     printf("Tests passed!\n");
     return 0;
 }


### PR DESCRIPTION
Adds the ability to use attributes to mark a static field as being a natively declared global on transpile.  This will cause the transpiler to replace any calls to get or set values for that field to the name of the native value provided, along with including any required headers for it.
