### PR TITLE
Make globals first class citizens 

### DIFF
--- a/Dntc.Common/Conversion/ConversionCatalog.cs
+++ b/Dntc.Common/Conversion/ConversionCatalog.cs
@@ -9,6 +9,7 @@ public class ConversionCatalog
     private readonly DefinitionCatalog _definitionCatalog;
     private readonly Dictionary<IlTypeName, TypeConversionInfo> _types = new();
     private readonly Dictionary<IlMethodId, MethodConversionInfo> _methods = new();
+    private readonly Dictionary<IlFieldId, GlobalConversionInfo> _globals = new();
 
     public ConversionCatalog(DefinitionCatalog definitionCatalog)
     {
@@ -44,6 +45,17 @@ public class ConversionCatalog
         }
 
         var message = $"Conversion catalog did not contain the type '{method.Value}'";
+        throw new InvalidOperationException(message);
+    }
+
+    public GlobalConversionInfo Find(IlFieldId fieldId)
+    {
+        if (_globals.TryGetValue(fieldId, out var info))
+        {
+            return info;
+        }
+
+        var message = $"Conversion catalog did not have did not contain a global for the field '{fieldId}'";
         throw new InvalidOperationException(message);
     }
 

--- a/Dntc.Common/Conversion/ConversionCatalog.cs
+++ b/Dntc.Common/Conversion/ConversionCatalog.cs
@@ -71,6 +71,10 @@ public class ConversionCatalog
                 AddNode(methodNode);
                 break;
             
+            case DependencyGraph.GlobalNode globalNode:
+                AddNode(globalNode);
+                break;
+            
             default:
                 throw new NotSupportedException(node.GetType().FullName);
         }
@@ -91,6 +95,25 @@ public class ConversionCatalog
             AddChildren(node);
             _types.Add(node.TypeName, new TypeConversionInfo(definition));
         }
+    }
+
+    private void AddNode(DependencyGraph.GlobalNode node)
+    {
+        if (_globals.ContainsKey(node.FieldId))
+        {
+            return;
+        }
+
+        var definition = _definitionCatalog.Get(node.FieldId);
+        if (definition == null)
+        {
+            var message = $"Dependency graph contained a node for global `{node.FieldId}` but no " +
+                          $"definition exists for it";
+            throw new InvalidOperationException(message);
+        }
+        
+        _globals.Add(node.FieldId, new GlobalConversionInfo(definition));
+        AddChildren(node);
     }
 
     private void AddNode(DependencyGraph.MethodNode node)

--- a/Dntc.Common/Conversion/GlobalConversionInfo.cs
+++ b/Dntc.Common/Conversion/GlobalConversionInfo.cs
@@ -1,0 +1,79 @@
+using Dntc.Common.Definitions;
+
+namespace Dntc.Common.Conversion;
+
+/// <summary>
+/// Contains information for how a global will be converted to C
+/// </summary>
+public class GlobalConversionInfo
+{
+    /// <summary>
+    /// The name this global has when referenced in .net
+    /// </summary>
+    public IlFieldId IlName { get; }
+   
+    /// <summary>
+    /// The type of value this global contains
+    /// </summary>
+    public IlTypeName Type { get; }
+    
+    /// <summary>
+    /// If true, this is a global that can be considered pre-declared and should not
+    /// have a declaration created when generating C code.
+    /// </summary>
+    public bool IsPredeclared { get; private set; }
+    
+    /// <summary>
+    /// The header this global will be declared in. If `null`, this is a type that does
+    /// not require a header reference.
+    /// </summary>
+    public HeaderName? Header { get; private set; }
+   
+    /// <summary>
+    /// The file that contains the global "implementation" (e.g. non-extern declaration)
+    /// </summary>
+    public CSourceFileName? SourceFileName { get; private set; }
+   
+    /// <summary>
+    /// What name this type will have in C
+    /// </summary>
+    public CGlobalName NameInC { get; private set; }
+
+    public GlobalConversionInfo(DefinedGlobal global)
+    {
+        IlName = global.IlName;
+        Type = global.IlType;
+
+        switch (global)
+        {
+            case DotNetDefinedGlobal dotNetDefinedGlobal:
+                SetupDotNetGlobal(dotNetDefinedGlobal);
+                break;
+            
+            case NativeDefinedGlobal nativeGlobal:
+                SetupNativeGlobal(nativeGlobal);
+                break;
+            
+            default:
+                throw new NotSupportedException(global.GetType().FullName);
+        }
+    }
+
+    private void SetupDotNetGlobal(DotNetDefinedGlobal global)
+    {
+        IsPredeclared = false;
+        
+        var declaringNamespace = new IlNamespace(global.Definition.DeclaringType.Namespace);
+        Header = Utils.GetHeaderName(declaringNamespace);
+        SourceFileName = Utils.GetSourceFileName(declaringNamespace);
+        NameInC = new CGlobalName(Utils.MakeValidCName(global.IlName.Value));
+    }
+
+    private void SetupNativeGlobal(NativeDefinedGlobal global)
+    {
+        IsPredeclared = true;
+        Header = global.HeaderFile;
+        SourceFileName = null;
+        NameInC = global.NativeName;
+    }
+}

--- a/Dntc.Common/Conversion/GlobalConversionInfo.cs
+++ b/Dntc.Common/Conversion/GlobalConversionInfo.cs
@@ -64,9 +64,10 @@ public class GlobalConversionInfo
         IsPredeclared = false;
         
         var declaringNamespace = new IlNamespace(global.Definition.DeclaringType.Namespace);
+        var fieldName = $"{global.Definition.DeclaringType.FullName}_{global.Definition.Name}";
         Header = Utils.GetHeaderName(declaringNamespace);
         SourceFileName = Utils.GetSourceFileName(declaringNamespace);
-        NameInC = new CGlobalName(Utils.MakeValidCName(global.IlName.Value));
+        NameInC = new CGlobalName(Utils.MakeValidCName(fieldName));
     }
 
     private void SetupNativeGlobal(NativeDefinedGlobal global)

--- a/Dntc.Common/Conversion/PlannedFileConverter.cs
+++ b/Dntc.Common/Conversion/PlannedFileConverter.cs
@@ -40,13 +40,9 @@ public class PlannedFileConverter
             .Select(x => new MethodDeclaration(x.ConversionInfo, x.Definition!, _conversionCatalog))
             .ToArray();
 
-        var globals = plannedHeaderFile.DeclaredTypes
-            .Select(x => _definitionCatalog.Get(x.IlName))
-            .Where(x => x != null)
-            .SelectMany(x => x!.Fields
-                .Where(y => y.isStatic)
-                .Where(y => !y.IsNativelyDefined)
-                .Select(y => new GlobalVariableDeclaration(x, y, _conversionCatalog, true)))
+        var globals = plannedHeaderFile.DeclaredGlobals
+            .Select(x => new { GlobalInfo = x, TypeInfo = _conversionCatalog.Find(x.Type)})
+            .Select(x => new GlobalVariableDeclaration(x.GlobalInfo, x.TypeInfo, true))
             .ToArray();
 
         return new HeaderFile(guard, includes, typeDeclarations, methodDeclarations, globals);
@@ -68,13 +64,9 @@ public class PlannedFileConverter
             })
             .ToArray();
 
-        var globals = plannedSourceFile.TypesWithGlobals
-            .Select(x => _definitionCatalog.Get(x.IlName))
-            .Where(x => x != null)
-            .SelectMany(x => x!.Fields
-                .Where(y => y.isStatic)
-                .Where(y => !y.IsNativelyDefined)
-                .Select(y => new GlobalVariableDeclaration(x, y, _conversionCatalog, false)))
+        var globals = plannedSourceFile.ImplementedGlobls
+            .Select(x => new { GlobalInfo = x, TypeInfo = _conversionCatalog.Find(x.Type)})
+            .Select(x => new GlobalVariableDeclaration(x.GlobalInfo, x.TypeInfo, false))
             .ToArray();
 
         var typeDeclarations = plannedSourceFile.DeclaredTypes

--- a/Dntc.Common/Conversion/TypeConversionInfo.cs
+++ b/Dntc.Common/Conversion/TypeConversionInfo.cs
@@ -27,11 +27,6 @@ public class TypeConversionInfo
     public HeaderName? Header { get; private set; }
    
     /// <summary>
-    /// The file that any static fields/globals are implemented in. Null 
-    /// </summary>
-    public CSourceFileName? SourceFileName { get; private set; }
-   
-    /// <summary>
     /// What name this type will have in C
     /// </summary>
     public CTypeName NameInC { get; private set; }
@@ -74,10 +69,6 @@ public class TypeConversionInfo
         IsPredeclared = false;
         Header = Utils.GetHeaderName(type.Namespace);
         NameInC = new CTypeName(Utils.MakeValidCName(type.IlName.Value));
-
-        SourceFileName = type.Fields.Any(x => x.isStatic)
-            ? Utils.GetSourceFileName(type.Namespace)
-            : null;
     }
 
     private void SetupDotNetFunctionPointer(DotNetFunctionPointerType functionPointer)
@@ -106,7 +97,6 @@ public class TypeConversionInfo
     {
         IsPredeclared = true;
         Header = type.HeaderFile;
-        SourceFileName = null;
         NameInC = type.NativeName;
     }
 
@@ -114,7 +104,6 @@ public class TypeConversionInfo
     {
         IsPredeclared = false;
         Header = type.HeaderName;
-        SourceFileName = null;
         NameInC = type.NativeName;
         ReferencedHeaders = type.ReferencedHeaders;
     }

--- a/Dntc.Common/Definitions/CustomDefinedMethods/StaticConstructorInitializerDefinedMethod.cs
+++ b/Dntc.Common/Definitions/CustomDefinedMethods/StaticConstructorInitializerDefinedMethod.cs
@@ -6,14 +6,14 @@ namespace Dntc.Common.Definitions.CustomDefinedMethods;
 
 public class StaticConstructorInitializerDefinedMethod : CustomDefinedMethod
 {
-    private const string Namespace = "Dntc.Utils";
+    private const string NamespaceName = "Dntc.Utils";
     private const string MethodName = "InitStaticConstructors";
     private const string BaseFileName = "dntc_utils";
     private const string FunctionName = "dntc_utils_init_static_constructors";
 
     private readonly HashSet<HeaderName> _referencedHeaders = [];
 
-    public static IlMethodId MethodId = new($"{Namespace}.{MethodName}()");
+    public static IlMethodId MethodId = new($"{NamespaceName}.{MethodName}()");
     
     private readonly List<MethodConversionInfo> _staticConstructors = [];
     
@@ -21,7 +21,7 @@ public class StaticConstructorInitializerDefinedMethod : CustomDefinedMethod
         : base(
             MethodId,
             new IlTypeName(typeof(void).FullName!), 
-            new IlNamespace(Namespace), 
+            new IlNamespace(NamespaceName), 
             new HeaderName($"{BaseFileName}.h"), 
             new CSourceFileName($"{BaseFileName}.c"), 
             new CFunctionName(FunctionName), 

--- a/Dntc.Common/Definitions/CustomDefinedType.cs
+++ b/Dntc.Common/Definitions/CustomDefinedType.cs
@@ -27,7 +27,7 @@ public abstract class CustomDefinedType : DefinedType
         NativeName = nativeName;
         ReferencedHeaders = referencedHeaders;
 
-        Fields = Array.Empty<Field>();
+        InstanceFields = Array.Empty<Field>();
         Methods = Array.Empty<IlMethodId>();
     }
     

--- a/Dntc.Common/Definitions/DefinedGlobal.cs
+++ b/Dntc.Common/Definitions/DefinedGlobal.cs
@@ -1,0 +1,13 @@
+namespace Dntc.Common.Definitions;
+
+public abstract class DefinedGlobal
+{
+    public IlFieldId IlName { get; }
+    public IlTypeName IlType { get; }
+    
+    protected DefinedGlobal(IlFieldId name, IlTypeName type)
+    {
+        IlName = name;
+        IlType = type;
+    }
+}

--- a/Dntc.Common/Definitions/DefinedType.cs
+++ b/Dntc.Common/Definitions/DefinedType.cs
@@ -2,11 +2,11 @@
 
 public abstract class DefinedType
 {
-    public record Field(IlTypeName Type, string Name, bool isStatic, bool IsNativelyDefined);
+    public record Field(IlTypeName Type, string Name);
     
     public IlTypeName IlName { get; protected set; }
     
-    public IReadOnlyList<Field> Fields { get; protected set; } = ArraySegment<Field>.Empty;
+    public IReadOnlyList<Field> InstanceFields { get; protected set; } = ArraySegment<Field>.Empty;
     public IReadOnlyList<IlMethodId> Methods { get; protected set; } = ArraySegment<IlMethodId>.Empty;
     public IReadOnlyList<IlTypeName> OtherReferencedTypes { get; protected set; } = ArraySegment<IlTypeName>.Empty;
     public IReadOnlyList<HeaderName> ReferencedHeaders { get; protected set; } = ArraySegment<HeaderName>.Empty;

--- a/Dntc.Common/Definitions/DotNetDefinedGlobal.cs
+++ b/Dntc.Common/Definitions/DotNetDefinedGlobal.cs
@@ -1,0 +1,22 @@
+using Mono.Cecil;
+
+namespace Dntc.Common.Definitions;
+
+public class DotNetDefinedGlobal : DefinedGlobal
+{
+    public FieldDefinition Definition { get; }
+    public IlTypeName DeclaringType { get; }
+    
+    public DotNetDefinedGlobal(FieldDefinition field) 
+        : base(new IlFieldId(field.FullName), new IlTypeName(field.FieldType.FullName))
+    {
+        if (!field.IsStatic)
+        {
+            var message = $"Cannot define {field.FullName} as a global as it's not static.";
+            throw new InvalidOperationException(message);
+        }
+
+        Definition = field;
+        DeclaringType = new IlTypeName(field.DeclaringType.FullName);
+    }
+}

--- a/Dntc.Common/Definitions/DotNetDefinedType.cs
+++ b/Dntc.Common/Definitions/DotNetDefinedType.cs
@@ -24,7 +24,8 @@ public class DotNetDefinedType : DefinedType
         }
         Namespace = new IlNamespace(rootDeclaringType.Namespace);
 
-        Fields = definition.Fields
+        InstanceFields = definition.Fields
+            .Where(x => !x.IsStatic)
             .Select(ConvertToField)
             .ToArray();
 
@@ -37,9 +38,7 @@ public class DotNetDefinedType : DefinedType
     {
         var type = new IlTypeName(fieldDefinition.FieldType.FullName);
         var name = fieldDefinition.Name;
-        var isStatic = fieldDefinition.IsStatic;
-        var nativeGlobalInfo = NativeGlobalOnTranspileInfo.FromAttributes(fieldDefinition.CustomAttributes, type.Value);
 
-        return new Field(type, name, isStatic, nativeGlobalInfo != null);
+        return new Field(type, name);
     }
 }

--- a/Dntc.Common/Definitions/NativeDefinedGlobal.cs
+++ b/Dntc.Common/Definitions/NativeDefinedGlobal.cs
@@ -1,0 +1,18 @@
+namespace Dntc.Common.Definitions;
+
+public class NativeDefinedGlobal : DefinedGlobal
+{
+    public HeaderName? HeaderFile { get; }
+    public CGlobalName NativeName { get; }
+    
+    public NativeDefinedGlobal(
+        IlFieldId ilName, 
+        IlTypeName type,
+        CGlobalName nativeName, 
+        HeaderName? headerFile) 
+        : base(ilName, type)
+    {
+        HeaderFile = headerFile;
+        NativeName = nativeName;
+    }
+}

--- a/Dntc.Common/Definitions/NativeDefinedType.cs
+++ b/Dntc.Common/Definitions/NativeDefinedType.cs
@@ -11,7 +11,7 @@ public class NativeDefinedType : DefinedType
         NativeName = nativeName;
         IlName = ilTypeName;
 
-        Fields = Array.Empty<Field>();
+        InstanceFields = Array.Empty<Field>();
         Methods = Array.Empty<IlMethodId>();
     }
 

--- a/Dntc.Common/Dependencies/DependencyGraph.cs
+++ b/Dntc.Common/Dependencies/DependencyGraph.cs
@@ -1,5 +1,4 @@
-﻿using System.Text;
-using Dntc.Common.Definitions;
+﻿using Dntc.Common.Definitions;
 using Dntc.Common.OpCodeHandling;
 using Mono.Cecil.Rocks;
 
@@ -9,7 +8,7 @@ public class DependencyGraph
 {
     public abstract record Node
     {
-        public List<Node> Children { get; } = new();
+        public List<Node> Children { get; } = [];
     }
 
     public record TypeNode(IlTypeName TypeName) : Node;
@@ -22,49 +21,58 @@ public class DependencyGraph
 
     public DependencyGraph(DefinitionCatalog definitionCatalog, IlMethodId rootMethod)
     {
-        Root = CreateNode(definitionCatalog, rootMethod, []);
+        var firstNode = CreateNode(definitionCatalog, rootMethod, []);
+        if (firstNode == null)
+        {
+            var message = $"Failed to create root node from '{rootMethod}'";
+            throw new InvalidOperationException(message);
+        }
+
+        Root = firstNode;
     }
 
-    private static Node CreateNode(DefinitionCatalog definitionCatalog, GenericInvokedMethod invokedMethod, List<Node> path)
+    private static MethodNode? CreateNode(DefinitionCatalog definitionCatalog, GenericInvokedMethod invokedMethod, List<Node> path)
     {
         var invokedDefinition = definitionCatalog.Get(invokedMethod.MethodId);
-        if (invokedDefinition == null)
+        if (invokedDefinition != null)
         {
-            // This generic with these specific type arguments is new, so we need to add a definition for it
-            var sourceMethod = definitionCatalog.Get(invokedMethod.OriginalMethodId);
-            if (sourceMethod == null)
-            {
-                var message = $"Generic method '{invokedMethod.MethodId}' refers to the original method " +
-                              $"'{invokedMethod.OriginalMethodId}', but that method's definition isn't known";
-                throw new InvalidOperationException(message);
-            }
-
-            // Clone the method for this particular use case
-            if (sourceMethod is not DotNetDefinedMethod dotNetDefinedMethod)
-            {
-                var message = $"Generic method '{invokedMethod.MethodId}' refers to the original method " +
-                              $"'{invokedMethod.OriginalMethodId}', but that method is not a dot net defined method, " +
-                              $"but is instead a {sourceMethod.GetType().FullName}";
-                throw new InvalidOperationException(message);
-            }
-
-            var newMethod = dotNetDefinedMethod.MakeGenericInstance(
-                invokedMethod.MethodId, 
-                invokedMethod.GenericArguments);
-            
-            definitionCatalog.Add([newMethod]);
+            return CreateNode(definitionCatalog, invokedMethod.MethodId, path);
         }
+        
+        // This generic with these specific type arguments is new, so we need to add a definition for it
+        var sourceMethod = definitionCatalog.Get(invokedMethod.OriginalMethodId);
+        if (sourceMethod == null)
+        {
+            var message = $"Generic method '{invokedMethod.MethodId}' refers to the original method " +
+                          $"'{invokedMethod.OriginalMethodId}', but that method's definition isn't known";
+            throw new InvalidOperationException(message);
+        }
+
+        // Clone the method for this particular use case
+        if (sourceMethod is not DotNetDefinedMethod dotNetDefinedMethod)
+        {
+            var message = $"Generic method '{invokedMethod.MethodId}' refers to the original method " +
+                          $"'{invokedMethod.OriginalMethodId}', but that method is not a dot net defined method, " +
+                          $"but is instead a {sourceMethod.GetType().FullName}";
+            throw new InvalidOperationException(message);
+        }
+
+        var newMethod = dotNetDefinedMethod.MakeGenericInstance(
+            invokedMethod.MethodId, 
+            invokedMethod.GenericArguments);
+            
+        definitionCatalog.Add([newMethod]);
 
         return CreateNode(definitionCatalog, invokedMethod.MethodId, path);
     }
 
-    private static Node CreateNode(
-        DefinitionCatalog definitionCatalog, 
-        IlMethodId methodId, 
-        List<Node> path, 
-        bool isStaticConstructor = false)
+    private static MethodNode? CreateNode(DefinitionCatalog definitionCatalog, IlMethodId methodId, List<Node> path)
     {
-        EnsureNotCircularReference(path, methodId);
+        if (IsInPath(path, methodId))
+        {
+            return null;
+        }
+        
         var method = definitionCatalog.Get(methodId);
         if (method == null)
         {
@@ -72,13 +80,17 @@ public class DependencyGraph
             throw new InvalidOperationException(message);
         }
 
+        var isStaticConstructor = method is DotNetDefinedMethod { Definition: { IsConstructor: true, IsStatic: true } };
         var node = new MethodNode(methodId, isStaticConstructor);
         path.Add(node);
 
         foreach (var type in method.GetReferencedTypes)
         {
             var typeNode = CreateNode(definitionCatalog, type, path);
-            node.Children.Add(typeNode);
+            if (typeNode != null)
+            {
+                node.Children.Add(typeNode);
+            }
         }
 
         if (method is DotNetDefinedMethod dotNetDefinedMethod)
@@ -92,7 +104,7 @@ public class DependencyGraph
 
             foreach (var calledMethod in dotNetDefinedMethod.InvokedMethods)
             {
-                Node methodNode;
+                Node? methodNode;
                 if (calledMethod is GenericInvokedMethod generic)
                 {
                     methodNode = CreateNode(definitionCatalog, generic, path);
@@ -102,19 +114,28 @@ public class DependencyGraph
                     methodNode = CreateNode(definitionCatalog, calledMethod.MethodId, path);
                 }
 
-                node.Children.Add(methodNode);
+                if (methodNode != null)
+                {
+                    node.Children.Add(methodNode);
+                }
             }
 
             foreach (var type in dotNetDefinedMethod.ReferencedTypes)
             {
                 var typeNode = CreateNode(definitionCatalog, type, path);
-                node.Children.Add(typeNode);
+                if (typeNode != null)
+                {
+                    node.Children.Add(typeNode);
+                }
             }
 
             foreach (var global in dotNetDefinedMethod.ReferencedGlobals)
             {
                 var globalNode = CreateNode(definitionCatalog, global, path);
-                node.Children.Add(globalNode);
+                if (globalNode != null)
+                {
+                    node.Children.Add(globalNode);
+                }
             }
         }
         
@@ -122,9 +143,13 @@ public class DependencyGraph
         return node;
     }
     
-    private static Node CreateNode(DefinitionCatalog definitionCatalog, IlTypeName typeName, List<Node> path)
+    private static TypeNode? CreateNode(DefinitionCatalog definitionCatalog, IlTypeName typeName, List<Node> path)
     {
-        EnsureNotCircularReference(path, typeName);
+        if (IsInPath(path, typeName))
+        {
+            return null;
+        }
+        
         var type = definitionCatalog.Get(typeName);
         if (type == null)
         {
@@ -143,16 +168,23 @@ public class DependencyGraph
         foreach (var subType in subTypes)
         {
             var subNode = CreateNode(definitionCatalog, subType, path);
-            node.Children.Add(subNode);
+            if (subNode != null)
+            {
+                node.Children.Add(subNode);
+            }
         }
         
         path.RemoveAt(path.Count - 1);
         return node;
     }
 
-    public static Node CreateNode(DefinitionCatalog definitionCatalog, IlFieldId fieldId, List<Node> path)
+    private static GlobalNode? CreateNode(DefinitionCatalog definitionCatalog, IlFieldId fieldId, List<Node> path)
     {
-        EnsureNotCircularReference(path, fieldId);
+        if (IsInPath(path, fieldId))
+        {
+            return null;
+        }
+        
         var field = definitionCatalog.Get(fieldId);
         if (field == null)
         {
@@ -166,6 +198,10 @@ public class DependencyGraph
         // If the declaring type has a static constructor, we need to depend on that. This will miss
         // any other types with static constructors that modify this static value, but there's not an
         // easy way to do that without analyzing *every* static constructor in the assembly.
+        //
+        // TODO: Maybe it makes more sense just to add any static constructors as a dependency before
+        // jumping to any new method or type. This is a bit easier now that we've converted the circular
+        // dependency system to return null instead of throwing an exception.
         if (field is DotNetDefinedGlobal dotNetGlobal)
         {
             var staticConstructor = dotNetGlobal.Definition
@@ -175,7 +211,10 @@ public class DependencyGraph
             if (staticConstructor != null)
             {
                 var newNode = CreateNode(definitionCatalog, new IlMethodId(staticConstructor.FullName), path);
-                node.Children.Add(newNode);
+                if (newNode != null)
+                {
+                    node.Children.Add(newNode);
+                }
             }
         }
 
@@ -183,84 +222,42 @@ public class DependencyGraph
         return node;
     }
 
-    // TODO: Don't exception on circular references, just stop going down them.
-    private static void EnsureNotCircularReference(List<Node> path, IlMethodId id)
+    private static bool IsInPath(List<Node> path, IlMethodId id)
     {
-        var referenceFound = false;
         foreach (var node in path)
         {
             if (node is MethodNode methodNode && methodNode.MethodId == id)
             {
-                referenceFound = true;
-                break;
+                return true;
             }
         }
 
-        if (referenceFound)
-        {
-            ThrowCircularReferenceException(path, id.Value);
-        }
-    }
-
-    private static void EnsureNotCircularReference(List<Node> path, IlTypeName typeName)
-    {
-        var referenceFound = false;
-        foreach (var node in path)
-        {
-            if (node is TypeNode typeNode && typeNode.TypeName == typeName)
-            {
-                referenceFound = true;
-                break;
-            }
-        }
-
-        if (referenceFound)
-        {
-            ThrowCircularReferenceException(path, typeName.Value);
-        }
+        return false;
     }
     
-    private static void EnsureNotCircularReference(List<Node> path, IlFieldId id)
+    private static bool IsInPath(List<Node> path, IlTypeName id)
     {
-        var referenceFound = false;
         foreach (var node in path)
         {
-            if (node is GlobalNode fieldNode && fieldNode.FieldId == id)
+            if (node is TypeNode typeNode && typeNode.TypeName == id)
             {
-                referenceFound = true;
-                break;
+                return true;
             }
         }
 
-        if (referenceFound)
-        {
-            ThrowCircularReferenceException(path, id.Value);
-        }
+        return false;
     }
-
-    private static void ThrowCircularReferenceException(List<Node> path, string finalName)
+    
+    private static bool IsInPath(List<Node> path, IlFieldId id)
     {
-        var pathString = new StringBuilder();
         foreach (var node in path)
         {
-            switch (node)
+            if (node is GlobalNode globalNode && globalNode.FieldId == id)
             {
-                case MethodNode methodNode:
-                    pathString.Append($"{methodNode.MethodId.Value} --> ");
-                    break;
-                
-                case TypeNode typeNode:
-                    pathString.Append($"{typeNode.TypeName.Value} --> ");
-                    break;
-                
-                default:
-                    throw new NotSupportedException(node.GetType().FullName);
+                return true;
             }
         }
 
-        pathString.Append(finalName);
-
-        var message = $"Circular reference found: {pathString}";
-        throw new InvalidOperationException(message);
+        return false;
     }
 }

--- a/Dntc.Common/OpCodeHandling/Handlers/LoadHandlers.cs
+++ b/Dntc.Common/OpCodeHandling/Handlers/LoadHandlers.cs
@@ -82,20 +82,8 @@ public class LoadHandlers : IOpCodeHandlerCollection
             }
             else if (field.IsStatic)
             {
-                var containedType = context.ConversionCatalog.Find(new IlTypeName(field.DeclaringType.FullName));
-                var definedType = context.DefinitionCatalog.Get(new IlTypeName(field.DeclaringType.FullName));
-                if (definedType == null)
-                {
-                    var message = $"No definition for type {field.DeclaringType.FullName}";
-                    throw new InvalidOperationException(message);
-                }
-
-                var staticFieldDefinition = definedType.Fields
-                    .Where(x => x.Name == field.Name)
-                    .Single(x => x.isStatic);
-
-                var staticFieldName = Utils.StaticFieldName(containedType, staticFieldDefinition);
-                var variable = new Variable(fieldType, staticFieldName, false);
+                var fieldConversionInfo = context.ConversionCatalog.Find(new IlFieldId(field.FullName));
+                var variable = new Variable(fieldType, fieldConversionInfo.NameInC.Value, false);
                 newExpression = new VariableValueExpression(variable);
             }
             else
@@ -121,19 +109,11 @@ public class LoadHandlers : IOpCodeHandlerCollection
         {
             var field = (FieldDefinition)context.CurrentInstruction.Operand;
             var declaringType = new IlTypeName(field.DeclaringType.FullName);
-            var nativeGlobalInfo = NativeGlobalOnTranspileInfo.FromAttributes(field.CustomAttributes, field.FullName);
-
-            List<IlTypeName> staticTypes = field.IsStatic ? [declaringType] : [];
-            var headers = new HashSet<HeaderName>(
-                nativeGlobalInfo?.HeaderName != null 
-                    ? [nativeGlobalInfo.HeaderName.Value]
-                    : []);
 
             return new OpCodeAnalysisResult
             {
                 ReferencedTypes = new HashSet<IlTypeName>([declaringType]),
-                TypesRequiringStaticConstruction = new HashSet<IlTypeName>(staticTypes),
-                ReferencedHeaders = headers,
+                ReferencedGlobal = field.IsStatic ? field : null,
             };
         }
     }

--- a/Dntc.Common/OpCodeHandling/OpCodeAnalysisResult.cs
+++ b/Dntc.Common/OpCodeHandling/OpCodeAnalysisResult.cs
@@ -1,9 +1,11 @@
-﻿namespace Dntc.Common.OpCodeHandling;
+﻿using Mono.Cecil;
+
+namespace Dntc.Common.OpCodeHandling;
 
 public class OpCodeAnalysisResult
 {
     public InvokedMethod? CalledMethod { get; init; }
     public IReadOnlySet<IlTypeName> ReferencedTypes { get; init; } = new HashSet<IlTypeName>();
-    public IReadOnlySet<IlTypeName> TypesRequiringStaticConstruction { get; init; } = new HashSet<IlTypeName>();
     public IReadOnlySet<HeaderName> ReferencedHeaders { get; init; } = new HashSet<HeaderName>();
+    public FieldDefinition? ReferencedGlobal { get; init; }
 }

--- a/Dntc.Common/Planning/ImplementationPlan.cs
+++ b/Dntc.Common/Planning/ImplementationPlan.cs
@@ -151,18 +151,6 @@ public class ImplementationPlan
         }
         
         header.AddDeclaredType(type);
-
-        if (type.SourceFileName != null)
-        {
-            if (!_sourceFiles.TryGetValue(type.SourceFileName.Value, out var sourceFile))
-            {
-                sourceFile = new PlannedSourceFile(type.SourceFileName.Value);
-                _sourceFiles[type.SourceFileName.Value] = sourceFile;
-            }
-            
-            AddReferencedHeaders(node, sourceFile);
-            sourceFile.AddTypeWithStaticField(type);
-        }
     }
 
     private void DeclareMethod(DependencyGraph.MethodNode node)

--- a/Dntc.Common/Planning/ImplementationPlan.cs
+++ b/Dntc.Common/Planning/ImplementationPlan.cs
@@ -58,6 +58,25 @@ public class ImplementationPlan
 
                     break;
                 
+                case DependencyGraph.GlobalNode globalNode:
+                    var global = _conversionCatalog.Find(globalNode.FieldId);
+                    if (global.Header != null)
+                    {
+                        headerFile.AddReferencedHeader(global.Header.Value);
+                    }
+
+                    var globalDefinition = _definitionCatalog.Get(globalNode.FieldId);
+                    if (globalDefinition != null)
+                    {
+                        var type = _conversionCatalog.Find(globalDefinition.IlType);
+                        if (type.Header != null)
+                        {
+                            headerFile.AddReferencedHeader(type.Header.Value);
+                        }
+                    }
+
+                    break;
+                
                 default:
                     throw new NotSupportedException(child.GetType().FullName);
             }
@@ -84,6 +103,25 @@ public class ImplementationPlan
                     {
                         sourceFile.AddReferencedHeader(childMethod.Header.Value);
                     }
+                    break;
+                
+                case DependencyGraph.GlobalNode globalNode:
+                    var global = _conversionCatalog.Find(globalNode.FieldId);
+                    if (global.Header != null)
+                    {
+                        sourceFile.AddReferencedHeader(global.Header.Value);
+                    }
+
+                    var globalDefinition = _definitionCatalog.Get(globalNode.FieldId);
+                    if (globalDefinition != null)
+                    {
+                        var type = _conversionCatalog.Find(globalDefinition.IlType);
+                        if (type.Header != null)
+                        {
+                            sourceFile.AddReferencedHeader(type.Header.Value);
+                        }
+                    }
+
                     break;
                 
                 default:
@@ -114,6 +152,11 @@ public class ImplementationPlan
                     AddStaticConstructorInitializer();
                 }
                 
+                break;
+            
+            case DependencyGraph.GlobalNode globalNode:
+                AddGlobalDeclaration(globalNode);
+                AddGlobalImplementation(globalNode);
                 break;
             
             default:
@@ -206,5 +249,41 @@ public class ImplementationPlan
         _staticConstructorInitializerAdded = true;
         var node = new DependencyGraph.MethodNode(StaticConstructorInitializerDefinedMethod.MethodId, false);
         ProcessNode(node);
+    }
+
+    private void AddGlobalDeclaration(DependencyGraph.GlobalNode node)
+    {
+        var global = _conversionCatalog.Find(node.FieldId);
+        if (global.IsPredeclared || global.Header == null)
+        {
+            return;
+        }
+        
+        if (!_headers.TryGetValue(global.Header.Value, out var header))
+        {
+            header = new PlannedHeaderFile(global.Header.Value);
+            _headers[global.Header.Value] = header;
+        }
+        
+        AddReferencedHeaders(node, header);
+        header.AddDeclaredGlobal(global);
+    }
+
+    private void AddGlobalImplementation(DependencyGraph.GlobalNode node)
+    {
+        var global = _conversionCatalog.Find(node.FieldId);
+        if (global.IsPredeclared || global.SourceFileName == null)
+        {
+            return;
+        }
+
+        if (!_sourceFiles.TryGetValue(global.SourceFileName.Value, out var sourceFile))
+        {
+            sourceFile = new PlannedSourceFile(global.SourceFileName.Value);
+            _sourceFiles[global.SourceFileName.Value] = sourceFile;
+        }
+        
+        AddReferencedHeaders(node, sourceFile);
+        sourceFile.AddImplementedGlobal(global);
     }
 }

--- a/Dntc.Common/Planning/PlannedHeaderFile.cs
+++ b/Dntc.Common/Planning/PlannedHeaderFile.cs
@@ -10,6 +10,7 @@ public class PlannedHeaderFile
     private readonly List<HeaderName> _referencedHeaders = [];
     private readonly List<TypeConversionInfo> _declaredTypes = [];
     private readonly List<MethodConversionInfo> _declaredMethods = [];
+    private readonly List<GlobalConversionInfo> _declaredGlobals = [];
     
     public HeaderName Name { get; }
 
@@ -29,6 +30,11 @@ public class PlannedHeaderFile
     /// in the order presented in this list.
     /// </summary>
     public IReadOnlyList<MethodConversionInfo> DeclaredMethods => _declaredMethods;
+
+    /// <summary>
+    /// Globals that are declared in this header.
+    /// </summary>
+    public IReadOnlyList<GlobalConversionInfo> DeclaredGlobals => _declaredGlobals;
 
     public PlannedHeaderFile(HeaderName name)
     {
@@ -56,6 +62,14 @@ public class PlannedHeaderFile
         if (!_declaredMethods.Contains(method))
         {
             _declaredMethods.Add(method);
+        }
+    }
+
+    public void AddDeclaredGlobal(GlobalConversionInfo global)
+    {
+        if (!_declaredGlobals.Contains(global))
+        {
+            _declaredGlobals.Add(global);
         }
     }
 }

--- a/Dntc.Common/Planning/PlannedSourceFile.cs
+++ b/Dntc.Common/Planning/PlannedSourceFile.cs
@@ -6,15 +6,15 @@ public class PlannedSourceFile
 {
     private readonly List<MethodConversionInfo> _implementedMethods = [];
     private readonly List<HeaderName> _referencedHeaders = [];
-    private readonly List<TypeConversionInfo> _typesWithGlobals = [];
     private readonly List<TypeConversionInfo> _declaredTypes = [];
+    private readonly List<GlobalConversionInfo> _globals = [];
     
     public CSourceFileName Name { get; }
 
     public IReadOnlyList<MethodConversionInfo> ImplementedMethods => _implementedMethods;
     public IReadOnlyList<HeaderName> ReferencedHeaders => _referencedHeaders;
-    public IReadOnlyList<TypeConversionInfo> TypesWithGlobals => _typesWithGlobals;
     public IReadOnlyList<TypeConversionInfo> DeclaredTypes => _declaredTypes;
+    public IReadOnlyList<GlobalConversionInfo> ImplementedGlobls => _globals;
 
     public PlannedSourceFile(CSourceFileName name)
     {
@@ -58,7 +58,7 @@ public class PlannedSourceFile
             }
 
             newSourceFile._implementedMethods.AddRange(sourceFile.ImplementedMethods);
-            newSourceFile._typesWithGlobals.AddRange(sourceFile.TypesWithGlobals);
+            newSourceFile._globals.AddRange(sourceFile._globals);
         }
         
         // Resolve which headers are actually required to be referenced (we shouldn't reference
@@ -92,11 +92,11 @@ public class PlannedSourceFile
         }
     }
 
-    public void AddTypeWithStaticField(TypeConversionInfo type)
+    public void AddImplementedGlobal(GlobalConversionInfo global)
     {
-        if (!_typesWithGlobals.Contains(type))
+        if (!_globals.Contains(global))
         {
-            _typesWithGlobals.Add(type);
+            _globals.Add(global);
         }
     }
 }

--- a/Dntc.Common/StringTypes.cs
+++ b/Dntc.Common/StringTypes.cs
@@ -16,7 +16,23 @@ public readonly record struct IlMethodId(string Value)
     }
 }
 
+public readonly record struct IlFieldId(string Value)
+{
+    public override string ToString()
+    {
+        return Value;
+    }
+}
+
 public readonly record struct CTypeName(string Value)
+{
+    public override string ToString()
+    {
+        return Value;
+    }
+}
+
+public readonly record struct CGlobalName(string Value)
 {
     public override string ToString()
     {

--- a/Dntc.Common/Syntax/GlobalVariableDeclaration.cs
+++ b/Dntc.Common/Syntax/GlobalVariableDeclaration.cs
@@ -4,17 +4,12 @@ using Dntc.Common.Definitions;
 namespace Dntc.Common.Syntax;
 
 public record GlobalVariableDeclaration(
-    DefinedType TypeDefinition, 
-    DefinedType.Field Field, 
-    ConversionCatalog Catalog,
+    GlobalConversionInfo Global, 
+    TypeConversionInfo Type,
     bool IsExtern)
 {
     public async Task WriteAsync(StreamWriter writer)
     {
-        var containerTypeInfo = Catalog.Find(TypeDefinition.IlName);
-        var fieldTypeInfo = Catalog.Find(Field.Type);
-
-        await writer.WriteLineAsync(
-            $"{(IsExtern ? "extern" : "")} {fieldTypeInfo.NameInC} {Utils.StaticFieldName(containerTypeInfo, Field)};");
+        await writer.WriteLineAsync($"{(IsExtern ? "extern" : "")} {Type.NameInC} {Global.NameInC};");
     }
 }

--- a/Dntc.Common/Syntax/TypeDeclaration.cs
+++ b/Dntc.Common/Syntax/TypeDeclaration.cs
@@ -32,13 +32,13 @@ public record TypeDeclaration(TypeConversionInfo TypeConversion, DefinedType Typ
     private async Task WriteDotNetDefinedTypeAsync(StreamWriter writer, DotNetDefinedType dotNetDefinedType)
     {
         await writer.WriteLineAsync("typedef struct {");
-        foreach (var field in dotNetDefinedType.Fields.Where(x => !x.isStatic))
+        foreach (var field in dotNetDefinedType.InstanceFields)
         {
             var fieldType = Catalog.Find(field.Type);
             await writer.WriteLineAsync($"\t{fieldType.NameInC} {Utils.MakeValidCName(field.Name)};");
         }
 
-        if (dotNetDefinedType.Fields.Count == 0)
+        if (dotNetDefinedType.InstanceFields.Count == 0)
         {
             // C doesn't allow empty structs
             await writer.WriteLineAsync("\tchar __dummy;");

--- a/Dntc.Common/Syntax/TypeDeclaration.cs
+++ b/Dntc.Common/Syntax/TypeDeclaration.cs
@@ -41,7 +41,7 @@ public record TypeDeclaration(TypeConversionInfo TypeConversion, DefinedType Typ
         if (dotNetDefinedType.InstanceFields.Count == 0)
         {
             // C doesn't allow empty structs
-            await writer.WriteLineAsync("\tchar __dummy;");
+            await writer.WriteLineAsync("\tchar __dummy; // Placeholder for empty type");
         }
 
         await writer.WriteLineAsync($"}} {TypeConversion.NameInC};");

--- a/Dntc.Common/Utils.cs
+++ b/Dntc.Common/Utils.cs
@@ -9,17 +9,6 @@ public static class Utils
 
     public static string LocalName(int localIndex) => $"__local_{localIndex}";
 
-    public static string StaticFieldName(TypeConversionInfo containingType, DefinedType.Field field)
-    {
-        if (!field.isStatic)
-        {
-            var message = $"Field '{containingType.IlName}.{field.Name} is not static";
-            throw new NotSupportedException(message);
-        }
-
-        return $"{containingType.NameInC}_{MakeValidCName(field.Name)}";
-    }
-
     public static CSourceFileName GetSourceFileName(IlNamespace csharpNamespace)
     {
         return new CSourceFileName($"{MakeValidCName(csharpNamespace.Value)}.c");

--- a/Dntc.Common/Utils.cs
+++ b/Dntc.Common/Utils.cs
@@ -24,6 +24,7 @@ public static class Utils
         return name.Replace('<', '_')
             .Replace('>', '_')
             .Replace(".", "_")
-            .Replace("/", "_"); // Instance methods have the type name with a slash in it
+            .Replace("/", "_") // Instance methods have the type name with a slash in it
+            .Replace("::", "_");
     }
 }

--- a/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.c
+++ b/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.c
@@ -6,8 +6,9 @@
 #include "ScratchpadCSharp.h"
 
 
- int32_t ScratchpadCSharp_SimpleFunctions_SomeStaticInt;
  ScratchpadCSharp_SimpleFunctions_Vector3 ScratchpadCSharp_SimpleFunctions_AStaticVector;
+ int32_t ScratchpadCSharp_SimpleFunctions_SomeStaticInt;
+ uint32_t ScratchpadCSharp_AttributeTests_StaticNumberField;
 
 int32_t ScratchpadCSharp_SimpleFunctions_BitwiseOps(int32_t a) {
 	return ((((a >> 1) | (a & 15)) << 2) ^ 255);

--- a/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.h
+++ b/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.h
@@ -38,14 +38,17 @@ typedef struct {
 } ScratchpadCSharp_GenericTests_StaticNumberGetter;
 
 typedef struct {
+	char __dummy; // Placeholder for empty type
 } ScratchpadCSharp_SimpleFunctions;
 
 typedef struct {
+	char __dummy; // Placeholder for empty type
 } ScratchpadCSharp_AttributeTests;
 
 
-extern int32_t ScratchpadCSharp_SimpleFunctions_SomeStaticInt;
 extern ScratchpadCSharp_SimpleFunctions_Vector3 ScratchpadCSharp_SimpleFunctions_AStaticVector;
+extern int32_t ScratchpadCSharp_SimpleFunctions_SomeStaticInt;
+extern uint32_t ScratchpadCSharp_AttributeTests_StaticNumberField;
 
 int32_t ScratchpadCSharp_SimpleFunctions_BitwiseOps(int32_t a);
 int32_t ScratchpadCSharp_SimpleFunctions_FnPointerTest(FnPtr_Int32_Int32_Returns_Int32 fn, int32_t x, int32_t y);


### PR DESCRIPTION
Static fields / globals were implemented as a hacky part of the pipeline as an extension of how instance fields were implemented.  This is causing more and more problems as more customization is needed for them.

So this PR gives globals/static fields their own definition type, and allows it to run through the dependency graph and pipeline the same way methods and types are.