### PR TITLE
Add support for custom file names

### DIFF
--- a/Dntc.Attributes/CustomFileNameAttribute.cs
+++ b/Dntc.Attributes/CustomFileNameAttribute.cs
@@ -1,0 +1,16 @@
+namespace Dntc.Attributes;
+
+/// <summary>
+/// Specifies that the item the attribute is on should be transpiled to a specific header and
+/// source file, instead of the ones that are computed for it.
+/// </summary>
+[AttributeUsage(
+    AttributeTargets.Method | 
+    AttributeTargets.Field | 
+    AttributeTargets.Struct | 
+    AttributeTargets.Property)]
+public class CustomFileNameAttribute(string sourceFileName, string headerFileName) : Attribute
+{
+    public string SourceFileName => sourceFileName;
+    public string HeaderFileName => headerFileName;
+}

--- a/Dntc.Common/Conversion/GlobalConversionInfo.cs
+++ b/Dntc.Common/Conversion/GlobalConversionInfo.cs
@@ -63,11 +63,21 @@ public class GlobalConversionInfo
     {
         IsPredeclared = false;
         
-        var declaringNamespace = new IlNamespace(global.Definition.DeclaringType.Namespace);
         var fieldName = $"{global.Definition.DeclaringType.FullName}_{global.Definition.Name}";
-        Header = Utils.GetHeaderName(declaringNamespace);
-        SourceFileName = Utils.GetSourceFileName(declaringNamespace);
         NameInC = new CGlobalName(Utils.MakeValidCName(fieldName));
+        
+        var customNaming = Utils.GetCustomFileName(global.Definition.CustomAttributes, global.Definition.FullName);
+        if (customNaming != null)
+        {
+            SourceFileName = customNaming.Value.Item1;
+            Header = customNaming.Value.Item2;
+        }
+        else
+        {
+            var declaringNamespace = new IlNamespace(global.Definition.DeclaringType.Namespace);
+            Header = Utils.GetHeaderName(declaringNamespace);
+            SourceFileName = Utils.GetSourceFileName(declaringNamespace);
+        }
     }
 
     private void SetupNativeGlobal(NativeDefinedGlobal global)

--- a/Dntc.Common/Conversion/MethodConversionInfo.cs
+++ b/Dntc.Common/Conversion/MethodConversionInfo.cs
@@ -94,8 +94,17 @@ public class MethodConversionInfo
         
         IsPredeclared = false;
 
-        Header = Utils.GetHeaderName(method.Namespace);
-        SourceFileName = Utils.GetSourceFileName(method.Namespace);
+        var customNaming = Utils.GetCustomFileName(method.Definition.CustomAttributes, method.Definition.FullName);
+        if (customNaming != null)
+        {
+            SourceFileName = customNaming.Value.Item1;
+            Header = customNaming.Value.Item2;
+        }
+        else
+        {
+            Header = Utils.GetHeaderName(method.Namespace);
+            SourceFileName = Utils.GetSourceFileName(method.Namespace);
+        }
 
         string functionName;
         if (customNameAttribute != null)

--- a/Dntc.Common/Conversion/TypeConversionInfo.cs
+++ b/Dntc.Common/Conversion/TypeConversionInfo.cs
@@ -67,8 +67,17 @@ public class TypeConversionInfo
     private void SetupDotNetType(DotNetDefinedType type)
     {
         IsPredeclared = false;
-        Header = Utils.GetHeaderName(type.Namespace);
         NameInC = new CTypeName(Utils.MakeValidCName(type.IlName.Value));
+
+        var customNaming = Utils.GetCustomFileName(type.Definition.CustomAttributes, type.IlName.Value);
+        if (customNaming != null)
+        {
+            Header = customNaming.Value.Item2;
+        }
+        else
+        {
+            Header = Utils.GetHeaderName(type.Namespace);
+        }
     }
 
     private void SetupDotNetFunctionPointer(DotNetFunctionPointerType functionPointer)

--- a/Dntc.Common/Planning/PlannedHeaderFile.cs
+++ b/Dntc.Common/Planning/PlannedHeaderFile.cs
@@ -43,7 +43,7 @@ public class PlannedHeaderFile
 
     public void AddReferencedHeader(HeaderName headerName)
     {
-        if (!_referencedHeaders.Contains(headerName))
+        if (headerName != Name && !_referencedHeaders.Contains(headerName))
         {
             _referencedHeaders.Add(headerName);
         }

--- a/Dntc.Common/Utils.cs
+++ b/Dntc.Common/Utils.cs
@@ -1,5 +1,7 @@
-﻿using Dntc.Common.Conversion;
+﻿using Dntc.Attributes;
+using Dntc.Common.Conversion;
 using Dntc.Common.Definitions;
+using Mono.Cecil;
 
 namespace Dntc.Common;
 
@@ -26,5 +28,40 @@ public static class Utils
             .Replace(".", "_")
             .Replace("/", "_") // Instance methods have the type name with a slash in it
             .Replace("::", "_");
+    }
+
+    public static (CSourceFileName, HeaderName)? GetCustomFileName(
+        IEnumerable<CustomAttribute> customAttributes, 
+        string attachedItemName)
+    {
+        var attribute = customAttributes
+            .SingleOrDefault(x => x.AttributeType.FullName == typeof(CustomFileNameAttribute).FullName);
+
+        if (attribute == null)
+        {
+            return null;
+        }
+        
+        if (attribute.ConstructorArguments.Count != 2)
+        {
+            var message =
+                $"Expected {attachedItemName}'s {typeof(CustomFileNameAttribute).FullName}'s " +
+                $"specification 2 have 2 arguments, but {attribute.ConstructorArguments.Count} were present";
+
+            throw new InvalidOperationException(message);
+        }
+        
+        var sourceFileName = attribute.ConstructorArguments[0].Value.ToString();
+        var headerName = attribute.ConstructorArguments[1].Value.ToString();
+        
+        if (sourceFileName == null || headerName == null)
+        {
+            var message = $"{attachedItemName}'s {typeof(CustomFileNameAttribute).FullName}'s had a null source " +
+                          $"file name and/or a null header file name";
+            
+            throw new InvalidOperationException(message);
+        }
+
+        return new(new CSourceFileName(sourceFileName), new HeaderName(headerName));
     }
 }

--- a/Samples/Scratchpad/ScratchpadCSharp/AttributeTests.cs
+++ b/Samples/Scratchpad/ScratchpadCSharp/AttributeTests.cs
@@ -46,4 +46,9 @@ public static class AttributeTests
         TestStructField.Value += 1;
         return TestStructField.Value;
     }
+
+    public static int CustomFileReferenceTestMethod()
+    {
+        return TestStructField.Value;
+    }
 }

--- a/Samples/Scratchpad/ScratchpadCSharp/AttributeTests.cs
+++ b/Samples/Scratchpad/ScratchpadCSharp/AttributeTests.cs
@@ -30,4 +30,20 @@ public static class AttributeTests
     {
         return 94;
     }
+
+    [CustomFileName("custom_file_test.c", "custom_file_test.h")]
+    public struct CustomFileTestStruct
+    {
+        public int Value;
+    }
+
+    [CustomFileName("custom_file_test.c", "custom_file_test.h")]
+    public static CustomFileTestStruct TestStructField;
+
+    [CustomFileName("custom_file_test.c", "custom_file_test.h")]
+    public static int CustomFileTestMethod()
+    {
+        TestStructField.Value += 1;
+        return TestStructField.Value;
+    }
 }

--- a/Samples/Scratchpad/scratchpad-debug.json
+++ b/Samples/Scratchpad/scratchpad-debug.json
@@ -36,7 +36,8 @@
     "System.UInt32 ScratchpadCSharp.AttributeTests::GetStaticNumberField()",
     "System.Void ScratchpadCSharp.AttributeTests::SetStaticNumberField(System.UInt32)",
     "System.Int32 ScratchpadCSharp.AttributeTests::RenamedMethodTest()",
-    "System.Int32 ScratchpadCSharp.AttributeTests::CustomFileTestMethod()"
+    "System.Int32 ScratchpadCSharp.AttributeTests::CustomFileTestMethod()",
+    "System.Int32 ScratchpadCSharp.AttributeTests::CustomFileReferenceTestMethod()"
   ],
   "OutputDirectory": "scratchpad_c/generated"
 }

--- a/Samples/Scratchpad/scratchpad-debug.json
+++ b/Samples/Scratchpad/scratchpad-debug.json
@@ -35,7 +35,8 @@
     "ScratchpadCSharp.SimpleFunctions/Vector3 ScratchpadCSharp.SimpleFunctions::GetStaticVector()",
     "System.UInt32 ScratchpadCSharp.AttributeTests::GetStaticNumberField()",
     "System.Void ScratchpadCSharp.AttributeTests::SetStaticNumberField(System.UInt32)",
-    "System.Int32 ScratchpadCSharp.AttributeTests::RenamedMethodTest()"
+    "System.Int32 ScratchpadCSharp.AttributeTests::RenamedMethodTest()",
+    "System.Int32 ScratchpadCSharp.AttributeTests::CustomFileTestMethod()"
   ],
   "OutputDirectory": "scratchpad_c/generated"
 }

--- a/Samples/Scratchpad/scratchpad-release.json
+++ b/Samples/Scratchpad/scratchpad-release.json
@@ -36,7 +36,8 @@
     "System.UInt32 ScratchpadCSharp.AttributeTests::GetStaticNumberField()",
     "System.Void ScratchpadCSharp.AttributeTests::SetStaticNumberField(System.UInt32)",
     "System.Int32 ScratchpadCSharp.AttributeTests::RenamedMethodTest()",
-    "System.Int32 ScratchpadCSharp.AttributeTests::CustomFileTestMethod()"
+    "System.Int32 ScratchpadCSharp.AttributeTests::CustomFileTestMethod()",
+    "System.Int32 ScratchpadCSharp.AttributeTests::CustomFileReferenceTestMethod()"
   ],
   "OutputDirectory": "scratchpad_c/generated"
 }

--- a/Samples/Scratchpad/scratchpad-release.json
+++ b/Samples/Scratchpad/scratchpad-release.json
@@ -35,7 +35,8 @@
     "ScratchpadCSharp.SimpleFunctions/Vector3 ScratchpadCSharp.SimpleFunctions::GetStaticVector()",
     "System.UInt32 ScratchpadCSharp.AttributeTests::GetStaticNumberField()",
     "System.Void ScratchpadCSharp.AttributeTests::SetStaticNumberField(System.UInt32)",
-    "System.Int32 ScratchpadCSharp.AttributeTests::RenamedMethodTest()"
+    "System.Int32 ScratchpadCSharp.AttributeTests::RenamedMethodTest()",
+    "System.Int32 ScratchpadCSharp.AttributeTests::CustomFileTestMethod()"
   ],
   "OutputDirectory": "scratchpad_c/generated"
 }

--- a/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.c
+++ b/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.c
@@ -1,6 +1,7 @@
 #include <math.h>
 #include <stdint.h>
 #include "../native_test.h"
+#include "custom_file_test.h"
 #include "dotnet_arrays.h"
 #include "fn_pointer_types.h"
 #include "ScratchpadCSharp.h"

--- a/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.c
+++ b/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.c
@@ -1,6 +1,7 @@
 #include <math.h>
 #include <stdint.h>
 #include "../native_test.h"
+#include "custom_file_test.h"
 #include "dotnet_arrays.h"
 #include "fn_pointer_types.h"
 #include "ScratchpadCSharp.h"
@@ -8,7 +9,6 @@
 
  ScratchpadCSharp_SimpleFunctions_Vector3 ScratchpadCSharp_SimpleFunctions_AStaticVector;
  int32_t ScratchpadCSharp_SimpleFunctions_SomeStaticInt;
- ScratchpadCSharp_AttributeTests_CustomFileTestStruct ScratchpadCSharp_AttributeTests_TestStructField;
 
 int32_t ScratchpadCSharp_SimpleFunctions_BitwiseOps(int32_t a) {
 	return ((((a >> 1) | (a & 15)) << 2) ^ 255);
@@ -278,5 +278,9 @@ void ScratchpadCSharp_AttributeTests_SetStaticNumberField(uint32_t num) {
 
 int32_t some_named_function() {
 	return 94;
+}
+
+int32_t ScratchpadCSharp_AttributeTests_CustomFileReferenceTestMethod() {
+	return ((&ScratchpadCSharp_AttributeTests_TestStructField)->Value);
 }
 

--- a/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.c
+++ b/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.c
@@ -1,7 +1,6 @@
 #include <math.h>
 #include <stdint.h>
 #include "../native_test.h"
-#include "custom_file_test.h"
 #include "dotnet_arrays.h"
 #include "fn_pointer_types.h"
 #include "ScratchpadCSharp.h"
@@ -9,6 +8,7 @@
 
  ScratchpadCSharp_SimpleFunctions_Vector3 ScratchpadCSharp_SimpleFunctions_AStaticVector;
  int32_t ScratchpadCSharp_SimpleFunctions_SomeStaticInt;
+ ScratchpadCSharp_AttributeTests_CustomFileTestStruct ScratchpadCSharp_AttributeTests_TestStructField;
 
 int32_t ScratchpadCSharp_SimpleFunctions_BitwiseOps(int32_t a) {
 	return ((((a >> 1) | (a & 15)) << 2) ^ 255);

--- a/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.h
+++ b/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.h
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include "../native_test.h"
+#include "custom_file_test.h"
 #include "dotnet_arrays.h"
 #include "fn_pointer_types.h"
 #include "ScratchpadCSharp.h"

--- a/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.h
+++ b/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.h
@@ -7,9 +7,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include "../native_test.h"
+#include "custom_file_test.h"
 #include "dotnet_arrays.h"
 #include "fn_pointer_types.h"
-#include "ScratchpadCSharp.h"
 
 typedef struct {
 	float X;
@@ -48,7 +48,6 @@ typedef struct {
 
 extern ScratchpadCSharp_SimpleFunctions_Vector3 ScratchpadCSharp_SimpleFunctions_AStaticVector;
 extern int32_t ScratchpadCSharp_SimpleFunctions_SomeStaticInt;
-extern ScratchpadCSharp_AttributeTests_CustomFileTestStruct ScratchpadCSharp_AttributeTests_TestStructField;
 
 int32_t ScratchpadCSharp_SimpleFunctions_BitwiseOps(int32_t a);
 int32_t ScratchpadCSharp_SimpleFunctions_FnPointerTest(FnPtr_Int32_Int32_Returns_Int32 fn, int32_t x, int32_t y);
@@ -88,5 +87,6 @@ ScratchpadCSharp_SimpleFunctions_Vector3 ScratchpadCSharp_SimpleFunctions_GetSta
 uint32_t ScratchpadCSharp_AttributeTests_GetStaticNumberField();
 void ScratchpadCSharp_AttributeTests_SetStaticNumberField(uint32_t num);
 int32_t some_named_function();
+int32_t ScratchpadCSharp_AttributeTests_CustomFileReferenceTestMethod();
 
 #endif // SCRATCHPADCSHARP_H_H

--- a/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.h
+++ b/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.h
@@ -7,7 +7,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include "../native_test.h"
-#include "custom_file_test.h"
 #include "dotnet_arrays.h"
 #include "fn_pointer_types.h"
 #include "ScratchpadCSharp.h"
@@ -49,6 +48,7 @@ typedef struct {
 
 extern ScratchpadCSharp_SimpleFunctions_Vector3 ScratchpadCSharp_SimpleFunctions_AStaticVector;
 extern int32_t ScratchpadCSharp_SimpleFunctions_SomeStaticInt;
+extern ScratchpadCSharp_AttributeTests_CustomFileTestStruct ScratchpadCSharp_AttributeTests_TestStructField;
 
 int32_t ScratchpadCSharp_SimpleFunctions_BitwiseOps(int32_t a);
 int32_t ScratchpadCSharp_SimpleFunctions_FnPointerTest(FnPtr_Int32_Int32_Returns_Int32 fn, int32_t x, int32_t y);

--- a/Samples/Scratchpad/scratchpad_c/generated/custom_file_test.c
+++ b/Samples/Scratchpad/scratchpad_c/generated/custom_file_test.c
@@ -1,0 +1,11 @@
+#include <stdint.h>
+#include "custom_file_test.h"
+#include "ScratchpadCSharp.h"
+
+
+
+int32_t ScratchpadCSharp_AttributeTests_CustomFileTestMethod() {
+	(*(&((&ScratchpadCSharp_AttributeTests_TestStructField)->Value))) = ((*(&((&ScratchpadCSharp_AttributeTests_TestStructField)->Value))) + 1);
+	return ((&ScratchpadCSharp_AttributeTests_TestStructField)->Value);
+}
+

--- a/Samples/Scratchpad/scratchpad_c/generated/custom_file_test.c
+++ b/Samples/Scratchpad/scratchpad_c/generated/custom_file_test.c
@@ -3,6 +3,7 @@
 #include "ScratchpadCSharp.h"
 
 
+ ScratchpadCSharp_AttributeTests_CustomFileTestStruct ScratchpadCSharp_AttributeTests_TestStructField;
 
 int32_t ScratchpadCSharp_AttributeTests_CustomFileTestMethod() {
 	(*(&((&ScratchpadCSharp_AttributeTests_TestStructField)->Value))) = ((*(&((&ScratchpadCSharp_AttributeTests_TestStructField)->Value))) + 1);

--- a/Samples/Scratchpad/scratchpad_c/generated/custom_file_test.h
+++ b/Samples/Scratchpad/scratchpad_c/generated/custom_file_test.h
@@ -1,0 +1,17 @@
+#ifndef CUSTOM_FILE_TEST_H_H
+#define CUSTOM_FILE_TEST_H_H
+
+
+#include <stdint.h>
+#include "custom_file_test.h"
+#include "ScratchpadCSharp.h"
+
+typedef struct {
+	int32_t Value;
+} ScratchpadCSharp_AttributeTests_CustomFileTestStruct;
+
+
+
+int32_t ScratchpadCSharp_AttributeTests_CustomFileTestMethod();
+
+#endif // CUSTOM_FILE_TEST_H_H

--- a/Samples/Scratchpad/scratchpad_c/generated/custom_file_test.h
+++ b/Samples/Scratchpad/scratchpad_c/generated/custom_file_test.h
@@ -3,7 +3,6 @@
 
 
 #include <stdint.h>
-#include "custom_file_test.h"
 #include "ScratchpadCSharp.h"
 
 typedef struct {
@@ -11,6 +10,7 @@ typedef struct {
 } ScratchpadCSharp_AttributeTests_CustomFileTestStruct;
 
 
+extern ScratchpadCSharp_AttributeTests_CustomFileTestStruct ScratchpadCSharp_AttributeTests_TestStructField;
 
 int32_t ScratchpadCSharp_AttributeTests_CustomFileTestMethod();
 


### PR DESCRIPTION
Added attribute which allows specifying that a struct, method, or global should be in a specifically named header and source file name.