### PR TITLE
Custom method declarations

### DIFF
--- a/Dntc.Attributes/CustomDeclarationAttribute.cs
+++ b/Dntc.Attributes/CustomDeclarationAttribute.cs
@@ -1,0 +1,27 @@
+namespace Dntc.Attributes;
+
+/// <summary>
+/// Specifies that the method has a custom declaration instead of the one generated for it. This
+/// is mostly required if the method needs to be defined via a macro. 
+/// </summary>
+/// <param name="fullDeclaration">
+/// The full declaration for this method when transpiled. This may include return types and
+/// all parameters. If the method this is attached to contains parameters, then the parameters
+/// will probably need to be contained in the custom declaration to be present. 
+/// </param>
+/// <param name="referredBy">
+/// If not null, the custom name that this method is called by.
+/// </param>
+/// <param name="headerName">
+/// If not null, the specified header is required to be included.
+/// </param>
+[AttributeUsage(AttributeTargets.Method)]
+public class CustomDeclarationAttribute(
+    string fullDeclaration, 
+    string? referredBy, 
+    string? headerName) : Attribute
+{
+    public string FullDeclaration => fullDeclaration;
+    public string? ReferredBy => referredBy;
+    public string? HeaderName => headerName;
+}

--- a/Dntc.Common/Conversion/MethodConversionInfo.cs
+++ b/Dntc.Common/Conversion/MethodConversionInfo.cs
@@ -1,6 +1,5 @@
 ﻿using Dntc.Attributes;
 using Dntc.Common.Definitions;
-using Dntc.Common.Syntax.Statements;
 
 namespace Dntc.Common.Conversion;
 
@@ -54,6 +53,11 @@ public class MethodConversionInfo
     /// Conversion info for all locals used
     /// </summary>
     public IReadOnlyList<Local> Locals { get; private set; }
+   
+    /// <summary>
+    /// If present, the method should be declared with this string
+    /// </summary>
+    public string? CustomDeclaration { get; private set; }
    
     public MethodConversionInfo(DefinedMethod method, ConversionCatalog conversionCatalog)
     {
@@ -125,7 +129,12 @@ public class MethodConversionInfo
             }
         }
 
-        NameInC = new CFunctionName(Utils.MakeValidCName(functionName));
+        if (method.CustomDeclaration != null)
+        {
+            CustomDeclaration = method.CustomDeclaration.Declaration;
+        }
+        
+        NameInC = method.CustomDeclaration?.ReferredBy ?? new CFunctionName(Utils.MakeValidCName(functionName));
     }
 
     private void SetupNativeMethod(NativeDefinedMethod method)

--- a/Dntc.Common/Definitions/DefinedMethod.cs
+++ b/Dntc.Common/Definitions/DefinedMethod.cs
@@ -14,7 +14,7 @@ public abstract class DefinedMethod
     
     /// <summary>
     /// Headers that are referenced by this method but cannot be inferred from initial static analysis. This is
-    /// mostly required for custom defined types, or headers due to customizations found during method analysis..
+    /// mostly required for custom defined types, or headers due to customizations found during method analysis.
     /// </summary>
     public IReadOnlyList<HeaderName> ReferencedHeaders { get; protected set; } = ArraySegment<HeaderName>.Empty;
     

--- a/Dntc.Common/Planning/ImplementationPlan.cs
+++ b/Dntc.Common/Planning/ImplementationPlan.cs
@@ -212,6 +212,13 @@ public class ImplementationPlan
         }
         
         AddReferencedHeaders(node, header);
+        
+        var methodDefinition = _definitionCatalog.Get(node.MethodId);
+        foreach (var referencedHeader in methodDefinition!.ReferencedHeaders)
+        {
+            header.AddReferencedHeader(referencedHeader);
+        }
+        
         header.AddDeclaredMethod(method);
     }
 

--- a/Dntc.Common/Syntax/MethodDeclaration.cs
+++ b/Dntc.Common/Syntax/MethodDeclaration.cs
@@ -12,14 +12,14 @@ public record MethodDeclaration(MethodConversionInfo Method, DefinedMethod Defin
             case DotNetDefinedMethod dotNetDefinedMethod:
                 await WriteAsync(writer, dotNetDefinedMethod);
                 break;
-            
+
             case CustomDefinedMethod customDefinedMethod:
                 await WriteAsync(writer, customDefinedMethod);
                 break;
-            
+
             case NativeDefinedMethod:
                 break; // Predefined method, so nothing to do
-            
+
             default:
                 throw new NotSupportedException(Definition.GetType().FullName);
         }
@@ -34,20 +34,19 @@ public record MethodDeclaration(MethodConversionInfo Method, DefinedMethod Defin
         else
         {
             await writer.WriteAsync($"{Method.ReturnTypeInfo.NameInC} {Method.NameInC}(");
+            for (var x = 0; x < dotNetDefinedMethod.Parameters.Count; x++)
+            {
+                if (x > 0) await writer.WriteAsync(", ");
+
+                var param = dotNetDefinedMethod.Parameters[x];
+                var paramType = Catalog.Find(param.Type);
+
+                var pointerSymbol = param.IsReference ? "*" : "";
+                await writer.WriteAsync($"{paramType.NameInC} {pointerSymbol}{param.Name}");
+            }
+
+            await writer.WriteAsync(")");
         }
-
-        for (var x = 0; x < dotNetDefinedMethod.Parameters.Count; x++)
-        {
-            if (x > 0) await writer.WriteAsync(", ");
-
-            var param = dotNetDefinedMethod.Parameters[x];
-            var paramType = Catalog.Find(param.Type);
-            
-            var pointerSymbol = param.IsReference ? "*" : "";
-            await writer.WriteAsync($"{paramType.NameInC} {pointerSymbol}{param.Name}");
-        }
-
-        await writer.WriteAsync(")");
     }
 
     private async Task WriteAsync(StreamWriter writer, CustomDefinedMethod customDefinedMethod)

--- a/Dntc.Common/Syntax/MethodDeclaration.cs
+++ b/Dntc.Common/Syntax/MethodDeclaration.cs
@@ -27,7 +27,15 @@ public record MethodDeclaration(MethodConversionInfo Method, DefinedMethod Defin
 
     private async Task WriteAsync(StreamWriter writer, DotNetDefinedMethod dotNetDefinedMethod)
     {
-        await writer.WriteAsync($"{Method.ReturnTypeInfo.NameInC} {Method.NameInC}(");
+        if (Method.CustomDeclaration != null)
+        {
+            await writer.WriteAsync(Method.CustomDeclaration);
+        }
+        else
+        {
+            await writer.WriteAsync($"{Method.ReturnTypeInfo.NameInC} {Method.NameInC}(");
+        }
+
         for (var x = 0; x < dotNetDefinedMethod.Parameters.Count; x++)
         {
             if (x > 0) await writer.WriteAsync(", ");

--- a/Samples/Scratchpad/ScratchpadCSharp/AttributeTests.cs
+++ b/Samples/Scratchpad/ScratchpadCSharp/AttributeTests.cs
@@ -51,4 +51,15 @@ public static class AttributeTests
     {
         return TestStructField.Value;
     }
+
+    [CustomDeclaration("DECLARE_TEST(custom_declared_method)", "custom_declared_method", "../macros.h")]
+    public static int CustomDeclaredMethod()
+    {
+        return 929;
+    }
+
+    public static int ReferToCustomDeclaredMethod()
+    {
+        return CustomDeclaredMethod();
+    }
 }

--- a/Samples/Scratchpad/scratchpad-debug.json
+++ b/Samples/Scratchpad/scratchpad-debug.json
@@ -37,7 +37,9 @@
     "System.Void ScratchpadCSharp.AttributeTests::SetStaticNumberField(System.UInt32)",
     "System.Int32 ScratchpadCSharp.AttributeTests::RenamedMethodTest()",
     "System.Int32 ScratchpadCSharp.AttributeTests::CustomFileTestMethod()",
-    "System.Int32 ScratchpadCSharp.AttributeTests::CustomFileReferenceTestMethod()"
+    "System.Int32 ScratchpadCSharp.AttributeTests::CustomFileReferenceTestMethod()",
+    "System.Int32 ScratchpadCSharp.AttributeTests::CustomDeclaredMethod()",
+    "System.Int32 ScratchpadCSharp.AttributeTests::ReferToCustomDeclaredMethod()"
   ],
   "OutputDirectory": "scratchpad_c/generated"
 }

--- a/Samples/Scratchpad/scratchpad-release.json
+++ b/Samples/Scratchpad/scratchpad-release.json
@@ -37,7 +37,9 @@
     "System.Void ScratchpadCSharp.AttributeTests::SetStaticNumberField(System.UInt32)",
     "System.Int32 ScratchpadCSharp.AttributeTests::RenamedMethodTest()",
     "System.Int32 ScratchpadCSharp.AttributeTests::CustomFileTestMethod()",
-    "System.Int32 ScratchpadCSharp.AttributeTests::CustomFileReferenceTestMethod()"
+    "System.Int32 ScratchpadCSharp.AttributeTests::CustomFileReferenceTestMethod()",
+    "System.Int32 ScratchpadCSharp.AttributeTests::CustomDeclaredMethod()",
+    "System.Int32 ScratchpadCSharp.AttributeTests::ReferToCustomDeclaredMethod()"
   ],
   "OutputDirectory": "scratchpad_c/generated"
 }

--- a/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.c
+++ b/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.c
@@ -1,5 +1,6 @@
 #include <math.h>
 #include <stdint.h>
+#include "../macros.h"
 #include "../native_test.h"
 #include "custom_file_test.h"
 #include "dotnet_arrays.h"
@@ -282,5 +283,13 @@ int32_t some_named_function() {
 
 int32_t ScratchpadCSharp_AttributeTests_CustomFileReferenceTestMethod() {
 	return ((&ScratchpadCSharp_AttributeTests_TestStructField)->Value);
+}
+
+DECLARE_TEST(custom_declared_method)) {
+	return 929;
+}
+
+int32_t ScratchpadCSharp_AttributeTests_ReferToCustomDeclaredMethod() {
+	return custom_declared_method();
 }
 

--- a/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.c
+++ b/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.c
@@ -285,7 +285,7 @@ int32_t ScratchpadCSharp_AttributeTests_CustomFileReferenceTestMethod() {
 	return ((&ScratchpadCSharp_AttributeTests_TestStructField)->Value);
 }
 
-DECLARE_TEST(custom_declared_method)) {
+DECLARE_TEST(custom_declared_method) {
 	return 929;
 }
 

--- a/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.h
+++ b/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.h
@@ -6,6 +6,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include "../macros.h"
 #include "../native_test.h"
 #include "custom_file_test.h"
 #include "dotnet_arrays.h"
@@ -88,7 +89,7 @@ uint32_t ScratchpadCSharp_AttributeTests_GetStaticNumberField();
 void ScratchpadCSharp_AttributeTests_SetStaticNumberField(uint32_t num);
 int32_t some_named_function();
 int32_t ScratchpadCSharp_AttributeTests_CustomFileReferenceTestMethod();
-DECLARE_TEST(custom_declared_method));
+DECLARE_TEST(custom_declared_method);
 int32_t ScratchpadCSharp_AttributeTests_ReferToCustomDeclaredMethod();
 
 #endif // SCRATCHPADCSHARP_H_H

--- a/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.h
+++ b/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.h
@@ -88,5 +88,7 @@ uint32_t ScratchpadCSharp_AttributeTests_GetStaticNumberField();
 void ScratchpadCSharp_AttributeTests_SetStaticNumberField(uint32_t num);
 int32_t some_named_function();
 int32_t ScratchpadCSharp_AttributeTests_CustomFileReferenceTestMethod();
+DECLARE_TEST(custom_declared_method));
+int32_t ScratchpadCSharp_AttributeTests_ReferToCustomDeclaredMethod();
 
 #endif // SCRATCHPADCSHARP_H_H

--- a/Samples/Scratchpad/scratchpad_c/generated/dntc_utils.h
+++ b/Samples/Scratchpad/scratchpad_c/generated/dntc_utils.h
@@ -2,6 +2,7 @@
 #define DNTC_UTILS_H_H
 
 
+#include "ScratchpadCSharp.h"
 
 
 

--- a/Samples/Scratchpad/scratchpad_c/macros.h
+++ b/Samples/Scratchpad/scratchpad_c/macros.h
@@ -1,0 +1,6 @@
+#ifndef MACROS_H
+#define MACROS_H
+
+#define DECLARE_TEST(name) int name()
+
+#endif //MACROS_H

--- a/Samples/Scratchpad/scratchpad_c/main.c
+++ b/Samples/Scratchpad/scratchpad_c/main.c
@@ -88,6 +88,9 @@ int main(void) {
     int32_t renamedFunctionValue = some_named_function();
     assert(renamedFunctionValue == 94);
 
+    int32_t declareTest = ScratchpadCSharp_AttributeTests_ReferToCustomDeclaredMethod();
+    assert(declareTest == 929);
+
     printf("Tests passed!\n");
     return 0;
 }


### PR DESCRIPTION
Added attribute allowing methods to have a custom declaration for them.  This is mostly required when defining a function via a macro, which may require special tokens for arguments.