### PR TITLE
Ignore in header attribute

### DIFF
--- a/Dntc.Attributes/IgnoreInHeaderAttribute.cs
+++ b/Dntc.Attributes/IgnoreInHeaderAttribute.cs
@@ -1,0 +1,19 @@
+namespace Dntc.Attributes;
+
+/// <summary>
+/// Instructs the transpiler to not place the item's declaration in the corresponding
+/// header file. Used to ensure a type, global, or function is file scoped and inaccessible
+/// to other files.
+///
+/// This can't be inferred by C# modifiers as it's not a direct 1-to-1 comparison between
+/// the two.
+/// </summary>
+[AttributeUsage(
+    AttributeTargets.Field | 
+    AttributeTargets.Struct | 
+    AttributeTargets.Method | 
+    AttributeTargets.Property)]
+public class IgnoreInHeaderAttribute : Attribute
+{
+    
+}

--- a/Dntc.Attributes/IgnoreInHeaderAttribute.cs
+++ b/Dntc.Attributes/IgnoreInHeaderAttribute.cs
@@ -11,8 +11,7 @@ namespace Dntc.Attributes;
 [AttributeUsage(
     AttributeTargets.Field | 
     AttributeTargets.Struct | 
-    AttributeTargets.Method | 
-    AttributeTargets.Property)]
+    AttributeTargets.Method)]
 public class IgnoreInHeaderAttribute : Attribute
 {
     

--- a/Dntc.Common/Conversion/GlobalConversionInfo.cs
+++ b/Dntc.Common/Conversion/GlobalConversionInfo.cs
@@ -1,3 +1,4 @@
+using Dntc.Attributes;
 using Dntc.Common.Definitions;
 
 namespace Dntc.Common.Conversion;
@@ -77,6 +78,15 @@ public class GlobalConversionInfo
             var declaringNamespace = new IlNamespace(global.Definition.DeclaringType.Namespace);
             Header = Utils.GetHeaderName(declaringNamespace);
             SourceFileName = Utils.GetSourceFileName(declaringNamespace);
+        }
+
+        var ignoreInHeader = global.Definition
+            .CustomAttributes
+            .Any(x => x.AttributeType.FullName == typeof(IgnoreInHeaderAttribute).FullName);
+
+        if (ignoreInHeader)
+        {
+            Header = null;
         }
     }
 

--- a/Dntc.Common/Conversion/MethodConversionInfo.cs
+++ b/Dntc.Common/Conversion/MethodConversionInfo.cs
@@ -135,6 +135,15 @@ public class MethodConversionInfo
         }
         
         NameInC = method.CustomDeclaration?.ReferredBy ?? new CFunctionName(Utils.MakeValidCName(functionName));
+
+        var ignoreInHeader = method.Definition
+            .CustomAttributes
+            .Any(x => x.AttributeType.FullName == typeof(IgnoreInHeaderAttribute).FullName);
+
+        if (ignoreInHeader)
+        {
+            Header = null;
+        }
     }
 
     private void SetupNativeMethod(NativeDefinedMethod method)

--- a/Dntc.Common/Conversion/PlannedFileConverter.cs
+++ b/Dntc.Common/Conversion/PlannedFileConverter.cs
@@ -64,7 +64,7 @@ public class PlannedFileConverter
             })
             .ToArray();
 
-        var globals = plannedSourceFile.ImplementedGlobls
+        var globals = plannedSourceFile.ImplementedGlobals
             .Select(x => new { GlobalInfo = x, TypeInfo = _conversionCatalog.Find(x.Type)})
             .Select(x => new GlobalVariableDeclaration(x.GlobalInfo, x.TypeInfo, false))
             .ToArray();

--- a/Dntc.Common/Planning/ImplementationPlan.cs
+++ b/Dntc.Common/Planning/ImplementationPlan.cs
@@ -199,7 +199,7 @@ public class ImplementationPlan
     private void DeclareMethod(DependencyGraph.MethodNode node)
     {
         var method = _conversionCatalog.Find(node.MethodId);
-        if (method.IsPredeclared)
+        if (method.IsPredeclared || method.Header == null)
         {
             // We aren't declaring this method, so nothing to do here
             return;

--- a/Dntc.Common/Planning/PlannedSourceFile.cs
+++ b/Dntc.Common/Planning/PlannedSourceFile.cs
@@ -14,7 +14,7 @@ public class PlannedSourceFile
     public IReadOnlyList<MethodConversionInfo> ImplementedMethods => _implementedMethods;
     public IReadOnlyList<HeaderName> ReferencedHeaders => _referencedHeaders;
     public IReadOnlyList<TypeConversionInfo> DeclaredTypes => _declaredTypes;
-    public IReadOnlyList<GlobalConversionInfo> ImplementedGlobls => _globals;
+    public IReadOnlyList<GlobalConversionInfo> ImplementedGlobals => _globals;
 
     public PlannedSourceFile(CSourceFileName name)
     {
@@ -97,6 +97,14 @@ public class PlannedSourceFile
         if (!_globals.Contains(global))
         {
             _globals.Add(global);
+        }
+    }
+
+    public void AddDeclaredType(TypeConversionInfo type)
+    {
+        if (!_declaredTypes.Contains(type))
+        {
+            _declaredTypes.Add(type);
         }
     }
 }

--- a/Samples/Scratchpad/ScratchpadCSharp/AttributeTests.cs
+++ b/Samples/Scratchpad/ScratchpadCSharp/AttributeTests.cs
@@ -63,4 +63,11 @@ public static class AttributeTests
     {
         return CustomDeclaredMethod();
     }
+
+    [IgnoreInHeader] public static int NonHeaderField = 1010;
+
+    public static int GetNonHeaderField()
+    {
+        return NonHeaderField;
+    }
 }

--- a/Samples/Scratchpad/ScratchpadCSharp/AttributeTests.cs
+++ b/Samples/Scratchpad/ScratchpadCSharp/AttributeTests.cs
@@ -63,11 +63,18 @@ public static class AttributeTests
     {
         return CustomDeclaredMethod();
     }
-
-    [IgnoreInHeader] public static int NonHeaderField = 1010;
-
-    public static int GetNonHeaderField()
+   
+    [IgnoreInHeader]
+    public struct NonHeaderStruct
     {
-        return NonHeaderField;
+        public int Value;
+    }
+
+    [IgnoreInHeader]
+    public static NonHeaderStruct NonHeaderStructGlobal = new() { Value = 1020 };
+
+    public static int GetNonHeaderStructValue()
+    {
+        return NonHeaderStructGlobal.Value;
     }
 }

--- a/Samples/Scratchpad/ScratchpadCSharp/AttributeTests.cs
+++ b/Samples/Scratchpad/ScratchpadCSharp/AttributeTests.cs
@@ -52,6 +52,7 @@ public static class AttributeTests
         return TestStructField.Value;
     }
 
+    [IgnoreInHeader]
     [CustomDeclaration("DECLARE_TEST(custom_declared_method)", "custom_declared_method", "../macros.h")]
     public static int CustomDeclaredMethod()
     {

--- a/Samples/Scratchpad/scratchpad-debug.json
+++ b/Samples/Scratchpad/scratchpad-debug.json
@@ -40,7 +40,7 @@
     "System.Int32 ScratchpadCSharp.AttributeTests::CustomFileReferenceTestMethod()",
     "System.Int32 ScratchpadCSharp.AttributeTests::CustomDeclaredMethod()",
     "System.Int32 ScratchpadCSharp.AttributeTests::ReferToCustomDeclaredMethod()",
-    "System.Int32 ScratchpadCSharp.AttributeTests::GetNonHeaderField()"
+    "System.Int32 ScratchpadCSharp.AttributeTests::GetNonHeaderStructValue()"
   ],
   "OutputDirectory": "scratchpad_c/generated"
 }

--- a/Samples/Scratchpad/scratchpad-debug.json
+++ b/Samples/Scratchpad/scratchpad-debug.json
@@ -39,7 +39,8 @@
     "System.Int32 ScratchpadCSharp.AttributeTests::CustomFileTestMethod()",
     "System.Int32 ScratchpadCSharp.AttributeTests::CustomFileReferenceTestMethod()",
     "System.Int32 ScratchpadCSharp.AttributeTests::CustomDeclaredMethod()",
-    "System.Int32 ScratchpadCSharp.AttributeTests::ReferToCustomDeclaredMethod()"
+    "System.Int32 ScratchpadCSharp.AttributeTests::ReferToCustomDeclaredMethod()",
+    "System.Int32 ScratchpadCSharp.AttributeTests::GetNonHeaderField()"
   ],
   "OutputDirectory": "scratchpad_c/generated"
 }

--- a/Samples/Scratchpad/scratchpad-release.json
+++ b/Samples/Scratchpad/scratchpad-release.json
@@ -40,7 +40,7 @@
     "System.Int32 ScratchpadCSharp.AttributeTests::CustomFileReferenceTestMethod()",
     "System.Int32 ScratchpadCSharp.AttributeTests::CustomDeclaredMethod()",
     "System.Int32 ScratchpadCSharp.AttributeTests::ReferToCustomDeclaredMethod()",
-    "System.Int32 ScratchpadCSharp.AttributeTests::GetNonHeaderField()"
+    "System.Int32 ScratchpadCSharp.AttributeTests::GetNonHeaderStructValue()"
   ],
   "OutputDirectory": "scratchpad_c/generated"
 }

--- a/Samples/Scratchpad/scratchpad-release.json
+++ b/Samples/Scratchpad/scratchpad-release.json
@@ -39,7 +39,8 @@
     "System.Int32 ScratchpadCSharp.AttributeTests::CustomFileTestMethod()",
     "System.Int32 ScratchpadCSharp.AttributeTests::CustomFileReferenceTestMethod()",
     "System.Int32 ScratchpadCSharp.AttributeTests::CustomDeclaredMethod()",
-    "System.Int32 ScratchpadCSharp.AttributeTests::ReferToCustomDeclaredMethod()"
+    "System.Int32 ScratchpadCSharp.AttributeTests::ReferToCustomDeclaredMethod()",
+    "System.Int32 ScratchpadCSharp.AttributeTests::GetNonHeaderField()"
   ],
   "OutputDirectory": "scratchpad_c/generated"
 }

--- a/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.c
+++ b/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.c
@@ -10,6 +10,7 @@
 
  ScratchpadCSharp_SimpleFunctions_Vector3 ScratchpadCSharp_SimpleFunctions_AStaticVector;
  int32_t ScratchpadCSharp_SimpleFunctions_SomeStaticInt;
+ int32_t ScratchpadCSharp_AttributeTests_NonHeaderField;
 
 int32_t ScratchpadCSharp_SimpleFunctions_BitwiseOps(int32_t a) {
 	return ((((a >> 1) | (a & 15)) << 2) ^ 255);
@@ -281,6 +282,11 @@ int32_t some_named_function() {
 	return 94;
 }
 
+void ScratchpadCSharp_AttributeTests__cctor() {
+	ScratchpadCSharp_AttributeTests_NonHeaderField = 1010;
+	return;
+}
+
 int32_t ScratchpadCSharp_AttributeTests_CustomFileReferenceTestMethod() {
 	return ((&ScratchpadCSharp_AttributeTests_TestStructField)->Value);
 }
@@ -291,5 +297,9 @@ DECLARE_TEST(custom_declared_method) {
 
 int32_t ScratchpadCSharp_AttributeTests_ReferToCustomDeclaredMethod() {
 	return custom_declared_method();
+}
+
+int32_t ScratchpadCSharp_AttributeTests_GetNonHeaderField() {
+	return ScratchpadCSharp_AttributeTests_NonHeaderField;
 }
 

--- a/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.c
+++ b/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.c
@@ -7,10 +7,13 @@
 #include "fn_pointer_types.h"
 #include "ScratchpadCSharp.h"
 
+typedef struct {
+	int32_t Value;
+} ScratchpadCSharp_AttributeTests_NonHeaderStruct;
 
  ScratchpadCSharp_SimpleFunctions_Vector3 ScratchpadCSharp_SimpleFunctions_AStaticVector;
  int32_t ScratchpadCSharp_SimpleFunctions_SomeStaticInt;
- int32_t ScratchpadCSharp_AttributeTests_NonHeaderField;
+ ScratchpadCSharp_AttributeTests_NonHeaderStruct ScratchpadCSharp_AttributeTests_NonHeaderStructGlobal;
 
 int32_t ScratchpadCSharp_SimpleFunctions_BitwiseOps(int32_t a) {
 	return ((((a >> 1) | (a & 15)) << 2) ^ 255);
@@ -283,7 +286,10 @@ int32_t some_named_function() {
 }
 
 void ScratchpadCSharp_AttributeTests__cctor() {
-	ScratchpadCSharp_AttributeTests_NonHeaderField = 1010;
+	ScratchpadCSharp_AttributeTests_NonHeaderStruct __local_0 = {0};
+	(*(&__local_0)) = ((ScratchpadCSharp_AttributeTests_NonHeaderStruct){0});
+	((&__local_0)->Value) = 1020;
+	ScratchpadCSharp_AttributeTests_NonHeaderStructGlobal = __local_0;
 	return;
 }
 
@@ -299,7 +305,7 @@ int32_t ScratchpadCSharp_AttributeTests_ReferToCustomDeclaredMethod() {
 	return custom_declared_method();
 }
 
-int32_t ScratchpadCSharp_AttributeTests_GetNonHeaderField() {
-	return ScratchpadCSharp_AttributeTests_NonHeaderField;
+int32_t ScratchpadCSharp_AttributeTests_GetNonHeaderStructValue() {
+	return ((&ScratchpadCSharp_AttributeTests_NonHeaderStructGlobal)->Value);
 }
 

--- a/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.h
+++ b/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.h
@@ -90,6 +90,6 @@ int32_t some_named_function();
 void ScratchpadCSharp_AttributeTests__cctor();
 int32_t ScratchpadCSharp_AttributeTests_CustomFileReferenceTestMethod();
 int32_t ScratchpadCSharp_AttributeTests_ReferToCustomDeclaredMethod();
-int32_t ScratchpadCSharp_AttributeTests_GetNonHeaderField();
+int32_t ScratchpadCSharp_AttributeTests_GetNonHeaderStructValue();
 
 #endif // SCRATCHPADCSHARP_H_H

--- a/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.h
+++ b/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.h
@@ -87,7 +87,9 @@ ScratchpadCSharp_SimpleFunctions_Vector3 ScratchpadCSharp_SimpleFunctions_GetSta
 uint32_t ScratchpadCSharp_AttributeTests_GetStaticNumberField();
 void ScratchpadCSharp_AttributeTests_SetStaticNumberField(uint32_t num);
 int32_t some_named_function();
+void ScratchpadCSharp_AttributeTests__cctor();
 int32_t ScratchpadCSharp_AttributeTests_CustomFileReferenceTestMethod();
 int32_t ScratchpadCSharp_AttributeTests_ReferToCustomDeclaredMethod();
+int32_t ScratchpadCSharp_AttributeTests_GetNonHeaderField();
 
 #endif // SCRATCHPADCSHARP_H_H

--- a/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.h
+++ b/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.h
@@ -6,7 +6,6 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include "../macros.h"
 #include "../native_test.h"
 #include "custom_file_test.h"
 #include "dotnet_arrays.h"
@@ -89,7 +88,6 @@ uint32_t ScratchpadCSharp_AttributeTests_GetStaticNumberField();
 void ScratchpadCSharp_AttributeTests_SetStaticNumberField(uint32_t num);
 int32_t some_named_function();
 int32_t ScratchpadCSharp_AttributeTests_CustomFileReferenceTestMethod();
-DECLARE_TEST(custom_declared_method);
 int32_t ScratchpadCSharp_AttributeTests_ReferToCustomDeclaredMethod();
 
 #endif // SCRATCHPADCSHARP_H_H

--- a/Samples/Scratchpad/scratchpad_c/generated/dntc_utils.c
+++ b/Samples/Scratchpad/scratchpad_c/generated/dntc_utils.c
@@ -5,5 +5,6 @@
 
 void dntc_utils_init_static_constructors(void) {
 	ScratchpadCSharp_SimpleFunctions__cctor();
+	ScratchpadCSharp_AttributeTests__cctor();
 }
 

--- a/Samples/Scratchpad/scratchpad_c/main.c
+++ b/Samples/Scratchpad/scratchpad_c/main.c
@@ -85,6 +85,9 @@ int main(void) {
     ScratchpadCSharp_AttributeTests_SetStaticNumberField(23);
     assert(static_number == 23);
 
+    uint32_t nonHeaderField = ScratchpadCSharp_AttributeTests_GetNonHeaderField();
+    assert(nonHeaderField == 1010);
+
     int32_t renamedFunctionValue = some_named_function();
     assert(renamedFunctionValue == 94);
 

--- a/Samples/Scratchpad/scratchpad_c/main.c
+++ b/Samples/Scratchpad/scratchpad_c/main.c
@@ -85,8 +85,8 @@ int main(void) {
     ScratchpadCSharp_AttributeTests_SetStaticNumberField(23);
     assert(static_number == 23);
 
-    uint32_t nonHeaderField = ScratchpadCSharp_AttributeTests_GetNonHeaderField();
-    assert(nonHeaderField == 1010);
+    uint32_t nonHeaderField = ScratchpadCSharp_AttributeTests_GetNonHeaderStructValue();
+    assert(nonHeaderField == 1020);
 
     int32_t renamedFunctionValue = some_named_function();
     assert(renamedFunctionValue == 94);


### PR DESCRIPTION
Add attribute that allows structs, globals, and methods to not be declared in header files and be source file scoped instead.