### PR TITLE
Allow different type of arrays

### DIFF
--- a/Dntc.Cli/Transpiler.cs
+++ b/Dntc.Cli/Transpiler.cs
@@ -4,6 +4,7 @@ using Dntc.Common.Conversion;
 using Dntc.Common.Conversion.Mutators;
 using Dntc.Common.Definitions;
 using Dntc.Common.Definitions.Definers;
+using Dntc.Common.Definitions.Mutators;
 using Dntc.Common.Dependencies;
 using Dntc.Common.Planning;
 using Mono.Cecil;
@@ -36,6 +37,9 @@ public class Transpiler
         definerPipeline.Append(new NativeTypeDefiner());
         definerPipeline.Append(new CustomDeclaredFieldDefiner());
         definerPipeline.Append(new CustomFunctionDefiner());
+
+        definerPipeline.AppendFieldMutator(new StaticallySizedArrayMutator(definerPipeline, definitionCatalog));
+        definerPipeline.AppendFieldMutator(new HeapAllocatedArrayMutator(definitionCatalog));
 
         conversionInfoCreator.AddTypeMutator(new IgnoredInHeadersMutator());
         conversionInfoCreator.AddTypeMutator(new CustomFileNameMutator());

--- a/Dntc.Cli/Transpiler.cs
+++ b/Dntc.Cli/Transpiler.cs
@@ -43,6 +43,7 @@ public class Transpiler
 
         conversionInfoCreator.AddTypeMutator(new IgnoredInHeadersMutator());
         conversionInfoCreator.AddTypeMutator(new CustomFileNameMutator());
+        conversionInfoCreator.AddTypeMutator(new ArrayLateNameBindingMutator(definitionCatalog, conversionInfoCreator));
        
         conversionInfoCreator.AddMethodMutator(new WithAttributeMutator());
         conversionInfoCreator.AddMethodMutator(new CustomFileNameMutator());

--- a/Dntc.Cli/Transpiler.cs
+++ b/Dntc.Cli/Transpiler.cs
@@ -38,7 +38,7 @@ public class Transpiler
         definerPipeline.Append(new CustomDeclaredFieldDefiner());
         definerPipeline.Append(new CustomFunctionDefiner());
 
-        definerPipeline.AppendFieldMutator(new StaticallySizedArrayMutator(definerPipeline, definitionCatalog));
+        definerPipeline.AppendFieldMutator(new StaticallySizedArrayMutator(definitionCatalog));
         definerPipeline.AppendFieldMutator(new HeapAllocatedArrayMutator(definitionCatalog));
 
         conversionInfoCreator.AddTypeMutator(new IgnoredInHeadersMutator());

--- a/Dntc.Common/Conversion/Mutators/ArrayLateNameBindingMutator.cs
+++ b/Dntc.Common/Conversion/Mutators/ArrayLateNameBindingMutator.cs
@@ -1,0 +1,50 @@
+using Dntc.Common.Definitions;
+using Dntc.Common.Definitions.CustomDefinedTypes;
+
+namespace Dntc.Common.Conversion.Mutators;
+
+/// <summary>
+/// Allows late binding names for array types. This is needed because we don't have a known
+/// name in C for the element type at definition time, we only know them after they've been
+/// guaranteed to be added to the definition catalog, so we know the true representation of the
+/// element type.
+/// </summary>
+public class ArrayLateNameBindingMutator : ITypeConversionMutator
+{
+    private readonly DefinitionCatalog _catalog;
+    private readonly ConversionInfoCreator _conversionInfoCreator;
+
+    public ArrayLateNameBindingMutator(DefinitionCatalog catalog, ConversionInfoCreator conversionInfoCreator)
+    {
+        _catalog = catalog;
+        _conversionInfoCreator = conversionInfoCreator;
+    }
+
+    public void Mutate(TypeConversionInfo conversionInfo)
+    {
+        if (conversionInfo.OriginalTypeDefinition is not ArrayDefinedType arrayDefinition)
+        {
+            return;
+        }
+
+        // We can't just pull the type out of the conversion catalog, because we may be
+        // creating the array type before the element type. So instead pull the definition
+        // out and create the conversion info now.
+        var elementDefinition = _catalog.Get(arrayDefinition.ElementType);
+        if (elementDefinition == null)
+        {
+            var message = $"Array type ${arrayDefinition.IlName} uses an element type of " +
+                          $"{arrayDefinition.ElementType}, but that type is not in the definition catalog";
+            throw new InvalidOperationException(message);
+        }
+
+        var elementConversionInfo = _conversionInfoCreator.Create(
+            elementDefinition,
+            elementDefinition.IlName.IsPointer());
+
+        conversionInfo.NameInC = arrayDefinition.FormTypeName(elementConversionInfo);
+
+        // Update the type definition's name in C for correct code generation.
+        arrayDefinition.NativeName = arrayDefinition.FormTypeName(elementConversionInfo);
+    }
+}

--- a/Dntc.Common/Conversion/Mutators/InitialValueMutator.cs
+++ b/Dntc.Common/Conversion/Mutators/InitialValueMutator.cs
@@ -28,7 +28,7 @@ public class InitialValueMutator : IFieldConversionMutator
             return;
         }
 
-        var returnType = _conversionCatalog.Find(new IlTypeName(field.FieldType.FullName));
+        var returnType = _conversionCatalog.Find(conversionInfo.FieldTypeConversionInfo.IlName);
         var expression = new LiteralValueExpression(attribute.ConstructorArguments[0].Value.ToString()!, returnType);
         conversionInfo.InitialValue = expression;
     }

--- a/Dntc.Common/Conversion/Mutators/StaticallySizedArrayFieldMutator.cs
+++ b/Dntc.Common/Conversion/Mutators/StaticallySizedArrayFieldMutator.cs
@@ -30,13 +30,7 @@ public class StaticallySizedArrayFieldMutator : IFieldConversionMutator
             return;
         }
 
-        var fieldType = field.FieldType;
-        if (fieldType.FullName == typeof(string).FullName)
-        {
-            fieldType = _charArrayType;
-        }
-
-        if (!fieldType.IsArray)
+        if (!field.FieldType.IsArray)
         {
             var message = $"StaticallySizedArrayAttribute was attached to the field {field.FullName} but " +
                           $"its field type is not an array type";

--- a/Dntc.Common/Conversion/Mutators/StaticallySizedArrayFieldMutator.cs
+++ b/Dntc.Common/Conversion/Mutators/StaticallySizedArrayFieldMutator.cs
@@ -51,20 +51,7 @@ public class StaticallySizedArrayFieldMutator : IFieldConversionMutator
 
             throw new InvalidOperationException(message);
         }
-        
-        // We need to get the derived type info of the array's element type, so we can
-        // accurately tell the array's type conversion info what it's native name is. This
-        // *should* not be a race condition because the dependency graph should have ensured
-        // that this field's type info is added to the conversion catalog before the field itself.
-        var elementType = new IlTypeName(fieldType.GetElementType().FullName);
-        var elementTypeInfo = _conversionCatalog.Find(elementType);
 
-        var sizeType = new IlTypeName(typeof(int).FullName!); // TODO: Figure out a way to make this configurable.
-        var definedType = new StaticallySizedArrayDefinedType(fieldType, elementTypeInfo, size, sizeType);
-        var fieldTypeInfo = new TypeConversionInfo(definedType, false);
-
-        // Replace the field's current conversion info with one based on a statically sized defined type
-        conversionInfo.FieldTypeConversionInfo = fieldTypeInfo;
         conversionInfo.StaticItemSize = size;
     }
 }

--- a/Dntc.Common/Definitions/CustomDefinedType.cs
+++ b/Dntc.Common/Definitions/CustomDefinedType.cs
@@ -10,7 +10,7 @@ public abstract class CustomDefinedType : DefinedType
 {
     public HeaderName? HeaderName { get; }
     public CSourceFileName? SourceFileName { get; }
-    public CTypeName NativeName { get; }
+    public CTypeName NativeName { get; set; }
     
     protected CustomDefinedType(
         IlTypeName ilTypeName, 

--- a/Dntc.Common/Definitions/CustomDefinedTypes/ArrayDefinedType.cs
+++ b/Dntc.Common/Definitions/CustomDefinedTypes/ArrayDefinedType.cs
@@ -14,12 +14,11 @@ public abstract class ArrayDefinedType : CustomDefinedType
         IlTypeName ilTypeName, 
         HeaderName? headerName, 
         CSourceFileName? sourceFileName, 
-        CTypeName nativeName, 
-        IReadOnlyList<HeaderName> referencedHeaders) 
+        IReadOnlyList<HeaderName> referencedHeaders)
         : base(ilTypeName, 
             headerName, 
             sourceFileName, 
-            nativeName, 
+            new CTypeName("<Late bound array name>"),
             [new IlTypeName(elementType.FullName)], 
             referencedHeaders)
     {

--- a/Dntc.Common/Definitions/CustomDefinedTypes/ArrayDefinedType.cs
+++ b/Dntc.Common/Definitions/CustomDefinedTypes/ArrayDefinedType.cs
@@ -46,4 +46,11 @@ public abstract class ArrayDefinedType : CustomDefinedType
         CBaseExpression arrayLengthField,
         CBaseExpression arrayInstance,
         DereferencedValueExpression index);
+
+    /// <summary>
+    /// Returns the C name for the array's element type
+    /// </summary>
+    /// <param name="elementTypeInfo"></param>
+    /// <returns></returns>
+    public abstract CTypeName FormTypeName(TypeConversionInfo elementTypeInfo);
 }

--- a/Dntc.Common/Definitions/CustomDefinedTypes/HeapArrayDefinedType.cs
+++ b/Dntc.Common/Definitions/CustomDefinedTypes/HeapArrayDefinedType.cs
@@ -15,7 +15,6 @@ public class HeapArrayDefinedType : ArrayDefinedType
             new IlTypeName(arrayType.FullName), 
             new HeaderName("dotnet_arrays.h"), 
             null, 
-            FormNativeName(arrayType),
             [new HeaderName("<stdio.h>"), new HeaderName("<stdlib.h>")])
     {
         if (!arrayType.IsArray)
@@ -41,16 +40,6 @@ typedef struct {{
         return new CustomCodeStatementSet(content);
     }
     
-    private static CTypeName FormNativeName(TypeReference type)
-    {
-        var elementType = type.GetElementType();
-        var convertedName = elementType.FullName
-            .Replace(".", "")
-            .Replace("/", "");
-        
-        return new CTypeName($"{convertedName}Array");
-    }
-
     public override CBaseExpression GetArraySizeExpression(
         CBaseExpression expressionToArray,
         ConversionCatalog conversionCatalog)

--- a/Dntc.Common/Definitions/CustomDefinedTypes/HeapArrayDefinedType.cs
+++ b/Dntc.Common/Definitions/CustomDefinedTypes/HeapArrayDefinedType.cs
@@ -64,4 +64,11 @@ typedef struct {{
     {
         return new ArrayLengthCheckStatementSet(arrayLengthField, arrayInstance, index);
     }
+
+    public override CTypeName FormTypeName(TypeConversionInfo elementTypeInfo)
+    {
+        var convertedName = Utils.MakeValidCName(ElementType.Value).Replace("_", "");
+
+        return new CTypeName($"{convertedName}Array");
+    }
 }

--- a/Dntc.Common/Definitions/CustomDefinedTypes/StaticallySizedArrayDefinedType.cs
+++ b/Dntc.Common/Definitions/CustomDefinedTypes/StaticallySizedArrayDefinedType.cs
@@ -12,12 +12,13 @@ public class StaticallySizedArrayDefinedType : ArrayDefinedType
 
     public StaticallySizedArrayDefinedType(
         TypeReference arrayType,
-        TypeConversionInfo elementTypeInfo, 
+        TypeConversionInfo elementTypeInfo,
+        IlTypeName ilTypeName,
         int size, 
         IlTypeName sizeType)
         : base(
             arrayType.GetElementType(),
-            new IlTypeName(arrayType.FullName),
+            ilTypeName,
             null,
             null,
             elementTypeInfo.NameInC,

--- a/Dntc.Common/Definitions/CustomDefinedTypes/StaticallySizedArrayDefinedType.cs
+++ b/Dntc.Common/Definitions/CustomDefinedTypes/StaticallySizedArrayDefinedType.cs
@@ -61,4 +61,9 @@ public class StaticallySizedArrayDefinedType : ArrayDefinedType
     {
         return new ArrayLengthCheckStatementSet(arrayLengthField, arrayInstance, index);
     }
+
+    public override CTypeName FormTypeName(TypeConversionInfo elementTypeInfo)
+    {
+        return elementTypeInfo.NameInC;
+    }
 }

--- a/Dntc.Common/Definitions/CustomDefinedTypes/StaticallySizedArrayDefinedType.cs
+++ b/Dntc.Common/Definitions/CustomDefinedTypes/StaticallySizedArrayDefinedType.cs
@@ -12,7 +12,6 @@ public class StaticallySizedArrayDefinedType : ArrayDefinedType
 
     public StaticallySizedArrayDefinedType(
         TypeReference arrayType,
-        TypeConversionInfo elementTypeInfo,
         IlTypeName ilTypeName,
         int size, 
         IlTypeName sizeType)
@@ -21,7 +20,6 @@ public class StaticallySizedArrayDefinedType : ArrayDefinedType
             ilTypeName,
             null,
             null,
-            elementTypeInfo.NameInC,
             [])
     {
         if (!arrayType.IsArray)

--- a/Dntc.Common/Definitions/CustomDefinedTypes/StaticallySizedArrayDefinedType.cs
+++ b/Dntc.Common/Definitions/CustomDefinedTypes/StaticallySizedArrayDefinedType.cs
@@ -20,7 +20,7 @@ public class StaticallySizedArrayDefinedType : ArrayDefinedType
             ilTypeName,
             null,
             null,
-            [])
+            [new HeaderName("<stdio.h>"), new HeaderName("<stdlib.h>")])
     {
         if (!arrayType.IsArray)
         {

--- a/Dntc.Common/Definitions/DefinedField.cs
+++ b/Dntc.Common/Definitions/DefinedField.cs
@@ -3,7 +3,7 @@ namespace Dntc.Common.Definitions;
 public abstract class DefinedField
 {
     public IlFieldId IlName { get; }
-    public IlTypeName IlType { get; }
+    public IlTypeName IlType { get; set; }
     public bool IsGlobal { get; }
     public IReadOnlyList<HeaderName> ReferencedHeaders { get; protected set; } = Array.Empty<HeaderName>();
     

--- a/Dntc.Common/Definitions/DefinitionCatalog.cs
+++ b/Dntc.Common/Definitions/DefinitionCatalog.cs
@@ -97,14 +97,6 @@ public class DefinitionCatalog
         {
             var fieldDefinition = _definerPipeline.Define(field);
             Add(fieldDefinition);
-            
-            // If the field type is an array, then we should add the definition if
-            // it doesn't already exist.
-            if (field.FieldType.IsArray && !_types.ContainsKey(new IlTypeName(field.FieldType.FullName)))
-            {
-                var definition = new HeapArrayDefinedType(field.FieldType);
-                Add(definition);
-            }
         }
     }
 

--- a/Dntc.Common/Definitions/Mutators/HeapAllocatedArrayMutator.cs
+++ b/Dntc.Common/Definitions/Mutators/HeapAllocatedArrayMutator.cs
@@ -23,6 +23,15 @@ public class HeapAllocatedArrayMutator : IFieldDefinitionMutator
             return;
         }
 
+        // This is a hack, but we need to ensure we don't create a heap allocated array
+        // when it's already been mutated as part of being a statically sized array. This works
+        // because the statically sized array mutator adjusts the ILName. We need a better way to
+        // detect if the heap allocated array definition should take ownership of this array or not.
+        if (!field.IlName.Value.EndsWith("[]"))
+        {
+            return;
+        }
+
         if (_definitionCatalog.Get(field.IlName) == null)
         {
             var typeDefinition = new HeapArrayDefinedType(cecilField.FieldType);

--- a/Dntc.Common/Definitions/Mutators/HeapAllocatedArrayMutator.cs
+++ b/Dntc.Common/Definitions/Mutators/HeapAllocatedArrayMutator.cs
@@ -1,0 +1,32 @@
+using Dntc.Common.Definitions.CustomDefinedTypes;
+using Mono.Cecil;
+
+namespace Dntc.Common.Definitions.Mutators;
+
+/// <summary>
+/// Sets up the relevant types in a definition for any unhandled array types use the transpiled
+/// heap allocated array defined type.
+/// </summary>
+public class HeapAllocatedArrayMutator : IFieldDefinitionMutator
+{
+    private readonly DefinitionCatalog _definitionCatalog;
+
+    public HeapAllocatedArrayMutator(DefinitionCatalog definitionCatalog)
+    {
+        _definitionCatalog = definitionCatalog;
+    }
+
+    public void Mutate(DefinedField field, FieldDefinition cecilField)
+    {
+        if (!cecilField.FieldType.IsArray)
+        {
+            return;
+        }
+
+        if (_definitionCatalog.Get(field.IlName) == null)
+        {
+            var typeDefinition = new HeapArrayDefinedType(cecilField.FieldType);
+            _definitionCatalog.Add([typeDefinition]);
+        }
+    }
+}

--- a/Dntc.Common/Definitions/Mutators/IFieldDefinitionMutator.cs
+++ b/Dntc.Common/Definitions/Mutators/IFieldDefinitionMutator.cs
@@ -1,0 +1,11 @@
+using Mono.Cecil;
+
+namespace Dntc.Common.Definitions.Mutators;
+
+/// <summary>
+/// Allows changing field definition.
+/// </summary>
+public interface IFieldDefinitionMutator
+{
+    void Mutate(DefinedField field, FieldDefinition cecilField);
+}

--- a/Dntc.Common/Definitions/Mutators/StaticallySizedArrayMutator.cs
+++ b/Dntc.Common/Definitions/Mutators/StaticallySizedArrayMutator.cs
@@ -1,0 +1,64 @@
+using Dntc.Attributes;
+using Dntc.Common.Conversion;
+using Dntc.Common.Definitions.CustomDefinedTypes;
+using Dntc.Common.Definitions.Definers;
+using Mono.Cecil;
+
+namespace Dntc.Common.Definitions.Mutators;
+
+/// <summary>
+/// Updates dntc definitions to point to a special IL name designated for statically sized arrays. This is
+/// required because we need to differentiate between these and heap allocated arrays (or other arrays).
+/// These must be run before heap allocated mutators.
+/// </summary>
+public class StaticallySizedArrayMutator : IFieldDefinitionMutator
+{
+    private readonly DefinitionGenerationPipeline _definitionGenerationPipeline;
+    private readonly DefinitionCatalog _definitionCatalog;
+
+    public StaticallySizedArrayMutator(
+        DefinitionGenerationPipeline definitionGenerationPipeline,
+        DefinitionCatalog definitionCatalog)
+    {
+        _definitionGenerationPipeline = definitionGenerationPipeline;
+        _definitionCatalog = definitionCatalog;
+    }
+
+    public void Mutate(DefinedField field, FieldDefinition cecilField)
+    {
+        if (!cecilField.FieldType.IsArray)
+        {
+            return;
+        }
+
+        var attribute = Utils.GetCustomAttribute(typeof(StaticallySizedArrayAttribute), cecilField);
+        if (attribute == null)
+        {
+            return;
+        }
+
+        if (!attribute.HasConstructorArguments || attribute.ConstructorArguments[0].Value is not int size)
+        {
+            var message = $"Field {cecilField.FullName}'s StaticallySizedArrayAttribute constructor did not have a " +
+                          $"single integer size value";
+
+            throw new InvalidOperationException(message);
+        }
+
+        // We need to get the derived type info of the array's element type, so we can
+        // accurately tell the array's type conversion info what it's native name is. Eventually
+        // there should be a better way to do this, but this is only needed for arrays.
+        var elementTypeDefinition = _definitionGenerationPipeline.Define(cecilField.FieldType.Resolve());
+        var elementTypeInfo = new TypeConversionInfo(elementTypeDefinition, cecilField.FieldType.IsPointer);
+
+        var sizeType = new IlTypeName(typeof(int).FullName!); // TODO: Figure out a way to make this configurable.
+
+        // We can't use the real IlName, because we need a custom iL name for this specific usage.
+        var ilName = new IlTypeName($"StaticallySizedArray({cecilField.FullName})");
+        var definedType = new StaticallySizedArrayDefinedType(cecilField.FieldType, elementTypeInfo, ilName, size, sizeType);
+        _definitionCatalog.Add([definedType]);
+
+        // Update the field to use the custom type IL name
+        field.IlType = ilName;
+    }
+}

--- a/Dntc.Common/Definitions/Mutators/StaticallySizedArrayMutator.cs
+++ b/Dntc.Common/Definitions/Mutators/StaticallySizedArrayMutator.cs
@@ -1,7 +1,5 @@
 using Dntc.Attributes;
-using Dntc.Common.Conversion;
 using Dntc.Common.Definitions.CustomDefinedTypes;
-using Dntc.Common.Definitions.Definers;
 using Mono.Cecil;
 
 namespace Dntc.Common.Definitions.Mutators;
@@ -13,14 +11,10 @@ namespace Dntc.Common.Definitions.Mutators;
 /// </summary>
 public class StaticallySizedArrayMutator : IFieldDefinitionMutator
 {
-    private readonly DefinitionGenerationPipeline _definitionGenerationPipeline;
     private readonly DefinitionCatalog _definitionCatalog;
 
-    public StaticallySizedArrayMutator(
-        DefinitionGenerationPipeline definitionGenerationPipeline,
-        DefinitionCatalog definitionCatalog)
+    public StaticallySizedArrayMutator(DefinitionCatalog definitionCatalog)
     {
-        _definitionGenerationPipeline = definitionGenerationPipeline;
         _definitionCatalog = definitionCatalog;
     }
 
@@ -45,17 +39,11 @@ public class StaticallySizedArrayMutator : IFieldDefinitionMutator
             throw new InvalidOperationException(message);
         }
 
-        // We need to get the derived type info of the array's element type, so we can
-        // accurately tell the array's type conversion info what it's native name is. Eventually
-        // there should be a better way to do this, but this is only needed for arrays.
-        var elementTypeDefinition = _definitionGenerationPipeline.Define(cecilField.FieldType.Resolve());
-        var elementTypeInfo = new TypeConversionInfo(elementTypeDefinition, cecilField.FieldType.IsPointer);
-
         var sizeType = new IlTypeName(typeof(int).FullName!); // TODO: Figure out a way to make this configurable.
 
         // We can't use the real IlName, because we need a custom iL name for this specific usage.
         var ilName = new IlTypeName($"StaticallySizedArray({cecilField.FullName})");
-        var definedType = new StaticallySizedArrayDefinedType(cecilField.FieldType, elementTypeInfo, ilName, size, sizeType);
+        var definedType = new StaticallySizedArrayDefinedType(cecilField.FieldType, ilName, size, sizeType);
         _definitionCatalog.Add([definedType]);
 
         // Update the field to use the custom type IL name

--- a/Dntc.Common/Planning/ImplementationPlan.cs
+++ b/Dntc.Common/Planning/ImplementationPlan.cs
@@ -253,11 +253,6 @@ public class ImplementationPlan
 
             sourceFile.AddDeclaredType(type);
         }
-        else
-        {
-            var message = $"Type '{type.IlName}' is not predeclared and has no header or source file set";
-            throw new InvalidOperationException(message);
-        }
     }
 
     private void DeclareMethod(DependencyGraph.MethodNode node)

--- a/Dntc.Common/Utils.cs
+++ b/Dntc.Common/Utils.cs
@@ -128,4 +128,10 @@ public static class Utils
         return method.CustomAttributes
             .SingleOrDefault(x => x.AttributeType.FullName == attributeType.FullName);
     }
+
+    public static CustomAttribute? GetCustomAttribute(Type attributeType, FieldDefinition field)
+    {
+        return field.CustomAttributes
+            .SingleOrDefault(x => x.AttributeType.FullName == attributeType.FullName);
+    }
 }

--- a/Samples/Scratchpad/ScratchpadCSharp/AttributeTests.cs
+++ b/Samples/Scratchpad/ScratchpadCSharp/AttributeTests.cs
@@ -142,11 +142,9 @@ public static class AttributeTests
         return obj.Value;
     }
 
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
     [InitialGlobalValue("\"abcdefg\"")]
     [StaticallySizedArray(8)]
     public static char[] StaticallySizedString;
-#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
 
     public struct StaticallySizedTest
     {

--- a/Samples/Scratchpad/ScratchpadCSharp/AttributeTests.cs
+++ b/Samples/Scratchpad/ScratchpadCSharp/AttributeTests.cs
@@ -145,7 +145,7 @@ public static class AttributeTests
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
     [InitialGlobalValue("\"abcdefg\"")]
     [StaticallySizedArray(8)]
-    public static string StaticallySizedString;
+    public static char[] StaticallySizedString;
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
 
     public struct StaticallySizedTest

--- a/Samples/Scratchpad/ScratchpadCSharp/ScratchpadCSharp.csproj
+++ b/Samples/Scratchpad/ScratchpadCSharp/ScratchpadCSharp.csproj
@@ -5,6 +5,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+        <NoWarn>8618</NoWarn>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/Samples/Scratchpad/ScratchpadCSharp/SingleFileTests.cs
+++ b/Samples/Scratchpad/ScratchpadCSharp/SingleFileTests.cs
@@ -27,6 +27,10 @@ public static class SingleFileTests
         return 0;
     }
 
+    [StaticallySizedArray(10)]
+    [InitialGlobalValue("{1,2,3,4,5,6,7,8,9,10}")]
+    public static int[] NumberArray;
+
     [CustomFunctionName("main")]
     public static int MainFunction()
     {
@@ -39,6 +43,7 @@ public static class SingleFileTests
         DoStuff();
 
         var output = AddOneMacro(10);
+        var number = NumberArray[3];
 
         return test.Value;
     }

--- a/Samples/Scratchpad/scratchpad-release.json
+++ b/Samples/Scratchpad/scratchpad-release.json
@@ -71,7 +71,7 @@
     "System.Int32 ScratchpadCSharp.AttributeTests::UnreferencedGlobalField",
     "System.String ScratchpadCSharp.AttributeTests::TestGlobalString",
     "System.Int32 ScratchpadCSharp.PluginTests::PluginGlobal",
-    "System.String ScratchpadCSharp.AttributeTests::StaticallySizedString",
+    "System.Char[] ScratchpadCSharp.AttributeTests::StaticallySizedString",
     "System.Int32 ScratchpadCSharp.AttributeTests::CustomDeclaredGlobalTest",
     "System.Int32 ScratchpadCSharp.SimpleFunctions::GlobalWithNoInitialValue"
   ],

--- a/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.c
+++ b/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.c
@@ -22,7 +22,7 @@ ScratchpadCSharp_AttributeTests_NonHeaderStruct NonHeaderGlobal = {0};
 int32_t ScratchpadCSharp_AttributeTests_UnreferencedGlobalField __attribute__ ((aligned (16))) = 123;
 char ScratchpadCSharp_AttributeTests_TestGlobalString[] = {0};
 int32_t ScratchpadCSharp_PluginTests_PluginGlobal __attribute__ ((aligned (8))) = {0};
-char ScratchpadCSharp_AttributeTests_StaticallySizedString[8] = "abcdefg";
+char* ScratchpadCSharp_AttributeTests_StaticallySizedString[8] = "abcdefg";
 INT_FIELD(custom_declared_global) = 675;
 int32_t ScratchpadCSharp_SimpleFunctions_GlobalWithNoInitialValue;
 

--- a/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.c
+++ b/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.c
@@ -22,7 +22,7 @@ ScratchpadCSharp_AttributeTests_NonHeaderStruct NonHeaderGlobal = {0};
 int32_t ScratchpadCSharp_AttributeTests_UnreferencedGlobalField __attribute__ ((aligned (16))) = 123;
 char ScratchpadCSharp_AttributeTests_TestGlobalString[] = {0};
 int32_t ScratchpadCSharp_PluginTests_PluginGlobal __attribute__ ((aligned (8))) = {0};
-char* ScratchpadCSharp_AttributeTests_StaticallySizedString[8] = "abcdefg";
+char ScratchpadCSharp_AttributeTests_StaticallySizedString[8] = "abcdefg";
 INT_FIELD(custom_declared_global) = 675;
 int32_t ScratchpadCSharp_SimpleFunctions_GlobalWithNoInitialValue;
 

--- a/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.c
+++ b/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.c
@@ -144,7 +144,7 @@ float ScratchpadCSharp_SimpleFunctions_SquareRootTest(float value) {
 	return ((float)sqrt(((double)value)));
 }
 
-uint16_t ScratchpadCSharp_SimpleFunctions_ArrayTest(SystemUInt16Array test) {
+uint16_t ScratchpadCSharp_SimpleFunctions_ArrayTest(<Late bound array name> test) {
 	uint16_t __local_0 = {0};
 	int32_t __local_1 = {0};
 	int32_t __local_2 = {0};

--- a/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.c
+++ b/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.c
@@ -144,7 +144,7 @@ float ScratchpadCSharp_SimpleFunctions_SquareRootTest(float value) {
 	return ((float)sqrt(((double)value)));
 }
 
-uint16_t ScratchpadCSharp_SimpleFunctions_ArrayTest(<Late bound array name> test) {
+uint16_t ScratchpadCSharp_SimpleFunctions_ArrayTest(SystemUInt16Array test) {
 	uint16_t __local_0 = {0};
 	int32_t __local_1 = {0};
 	int32_t __local_2 = {0};

--- a/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.h
+++ b/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.h
@@ -44,7 +44,7 @@ typedef struct {
 } ScratchpadCSharp_AttributeTests_CustomFieldNameStruct;
 
 typedef struct {
-	int32_t NumberArray[10];
+	System_Int32 NumberArray[10];
 } ScratchpadCSharp_AttributeTests_StaticallySizedTest;
 
 typedef struct {
@@ -61,7 +61,7 @@ extern int32_t ScratchpadCSharp_SimpleFunctions_SomeStaticInt;
 extern int32_t ScratchpadCSharp_AttributeTests_UnreferencedGlobalField;
 extern char ScratchpadCSharp_AttributeTests_TestGlobalString[];
 extern int32_t ScratchpadCSharp_PluginTests_PluginGlobal;
-extern char ScratchpadCSharp_AttributeTests_StaticallySizedString[8];
+extern char* ScratchpadCSharp_AttributeTests_StaticallySizedString[8];
 extern INT_FIELD(custom_declared_global);
 extern int32_t ScratchpadCSharp_SimpleFunctions_GlobalWithNoInitialValue;
 

--- a/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.h
+++ b/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.h
@@ -44,7 +44,7 @@ typedef struct {
 } ScratchpadCSharp_AttributeTests_CustomFieldNameStruct;
 
 typedef struct {
-	System_Int32 NumberArray[10];
+	<Late bound array name> NumberArray[10];
 } ScratchpadCSharp_AttributeTests_StaticallySizedTest;
 
 typedef struct {
@@ -81,7 +81,7 @@ ScratchpadCSharp_SimpleFunctions_Vector2 ScratchpadCSharp_SimpleFunctions_Vector
 ScratchpadCSharp_SimpleFunctions_Triangle ScratchpadCSharp_SimpleFunctions_TriangleAdd(ScratchpadCSharp_SimpleFunctions_Triangle a, ScratchpadCSharp_SimpleFunctions_Triangle b);
 ScratchpadCSharp_SimpleFunctions_Triangle ScratchpadCSharp_SimpleFunctions_TriangleBuilder(float x0, float y0, float x1, float y1, float x2, float y2);
 float ScratchpadCSharp_SimpleFunctions_SquareRootTest(float value);
-uint16_t ScratchpadCSharp_SimpleFunctions_ArrayTest(SystemUInt16Array test);
+uint16_t ScratchpadCSharp_SimpleFunctions_ArrayTest(<Late bound array name> test);
 void ScratchpadCSharp_SimpleFunctions_Vector3__ctor(ScratchpadCSharp_SimpleFunctions_Vector3 *__this, float x, float y, float z);
 ScratchpadCSharp_SimpleFunctions_Vector3 ScratchpadCSharp_SimpleFunctions_ConstructorTest(float x, float y, float z);
 void ScratchpadCSharp_SimpleFunctions_RefTest(ScratchpadCSharp_SimpleFunctions_Vector3 *vector, float *floatToAdd, float amount);

--- a/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.h
+++ b/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.h
@@ -61,7 +61,7 @@ extern int32_t ScratchpadCSharp_SimpleFunctions_SomeStaticInt;
 extern int32_t ScratchpadCSharp_AttributeTests_UnreferencedGlobalField;
 extern char ScratchpadCSharp_AttributeTests_TestGlobalString[];
 extern int32_t ScratchpadCSharp_PluginTests_PluginGlobal;
-extern char* ScratchpadCSharp_AttributeTests_StaticallySizedString[8];
+extern char ScratchpadCSharp_AttributeTests_StaticallySizedString[8];
 extern INT_FIELD(custom_declared_global);
 extern int32_t ScratchpadCSharp_SimpleFunctions_GlobalWithNoInitialValue;
 

--- a/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.h
+++ b/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.h
@@ -44,7 +44,7 @@ typedef struct {
 } ScratchpadCSharp_AttributeTests_CustomFieldNameStruct;
 
 typedef struct {
-	<Late bound array name> NumberArray[10];
+	int32_t NumberArray[10];
 } ScratchpadCSharp_AttributeTests_StaticallySizedTest;
 
 typedef struct {
@@ -81,7 +81,7 @@ ScratchpadCSharp_SimpleFunctions_Vector2 ScratchpadCSharp_SimpleFunctions_Vector
 ScratchpadCSharp_SimpleFunctions_Triangle ScratchpadCSharp_SimpleFunctions_TriangleAdd(ScratchpadCSharp_SimpleFunctions_Triangle a, ScratchpadCSharp_SimpleFunctions_Triangle b);
 ScratchpadCSharp_SimpleFunctions_Triangle ScratchpadCSharp_SimpleFunctions_TriangleBuilder(float x0, float y0, float x1, float y1, float x2, float y2);
 float ScratchpadCSharp_SimpleFunctions_SquareRootTest(float value);
-uint16_t ScratchpadCSharp_SimpleFunctions_ArrayTest(<Late bound array name> test);
+uint16_t ScratchpadCSharp_SimpleFunctions_ArrayTest(SystemUInt16Array test);
 void ScratchpadCSharp_SimpleFunctions_Vector3__ctor(ScratchpadCSharp_SimpleFunctions_Vector3 *__this, float x, float y, float z);
 ScratchpadCSharp_SimpleFunctions_Vector3 ScratchpadCSharp_SimpleFunctions_ConstructorTest(float x, float y, float z);
 void ScratchpadCSharp_SimpleFunctions_RefTest(ScratchpadCSharp_SimpleFunctions_Vector3 *vector, float *floatToAdd, float amount);

--- a/Samples/Scratchpad/scratchpad_c/generated/dotnet_arrays.h
+++ b/Samples/Scratchpad/scratchpad_c/generated/dotnet_arrays.h
@@ -9,7 +9,7 @@
 typedef struct {
     int32_t length;
     uint16_t *items;
-} SystemUInt16Array;
+} <Late bound array name>;
 
 
 

--- a/Samples/Scratchpad/scratchpad_c/generated/dotnet_arrays.h
+++ b/Samples/Scratchpad/scratchpad_c/generated/dotnet_arrays.h
@@ -11,11 +11,6 @@ typedef struct {
     uint16_t *items;
 } SystemUInt16Array;
 
-typedef struct {
-    int32_t length;
-    int32_t *items;
-} SystemInt32Array;
-
 
 
 #endif // DOTNET_ARRAYS_H_H

--- a/Samples/Scratchpad/scratchpad_c/generated/dotnet_arrays.h
+++ b/Samples/Scratchpad/scratchpad_c/generated/dotnet_arrays.h
@@ -9,7 +9,7 @@
 typedef struct {
     int32_t length;
     uint16_t *items;
-} <Late bound array name>;
+} SystemUInt16Array;
 
 
 

--- a/Samples/Scratchpad/scratchpad_c_single_file/main.c
+++ b/Samples/Scratchpad/scratchpad_c_single_file/main.c
@@ -1,4 +1,6 @@
 #include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include "header_test2.h"
 #include "header_test1.h"
 
@@ -6,6 +8,7 @@ typedef struct {
 	int32_t Value;
 } ScratchpadCSharp_SingleFileTests_SomeStruct;
 
+int32_t ScratchpadCSharp_SingleFileTests_NumberArray[10] = {1,2,3,4,5,6,7,8,9,10};
 
 #define addOneMacro(a) ((a) + 1)
 int32_t main(void) {
@@ -15,5 +18,10 @@ int32_t main(void) {
 	do_stuff2();
 	do_stuff();
 	addOneMacro(10);
+	if (10 <= 3) {
+		printf("Attempted to access to ScratchpadCSharp_SingleFileTests_NumberArray[%d], but only %u items are in the array", 3, 10);
+		abort();
+	}
+	ScratchpadCSharp_SingleFileTests_NumberArray[3];
 	return (__local_0.Value);
 }


### PR DESCRIPTION
In C you usually have two types of arrays, heap allocated arrays and constant sized arrays.  When a C# array should be heap allocated vs statically sized is usually dependent on it's usage (e.g. not all `int[]` arrays should be heap or statically sized). 

This allows customizing the definition and conversion logic to allow the customization of types for an individual field, allowing some arrays to be heap allocated while others statically sized. This also fixes bugs where solutions with only statically sized arrays were having heap allocated definitions created for them.