### PR TITLE
Enums shouldn't reference System.Enum

### DIFF
--- a/Dntc.Common/Definitions/DotNetDefinedType.cs
+++ b/Dntc.Common/Definitions/DotNetDefinedType.cs
@@ -30,7 +30,8 @@ public class DotNetDefinedType : DefinedType
         
         if (definition.BaseType != null &&
             definition.BaseType.FullName != typeof(object).FullName &&
-            definition.BaseType.FullName != typeof(ValueType).FullName)
+            definition.BaseType.FullName != typeof(ValueType).FullName &&
+            definition.BaseType.FullName != typeof(Enum).FullName)
         {
             var baseTypeName = new IlTypeName(definition.BaseType.FullName);
 


### PR DESCRIPTION
While I'm not sure why the sample projects don't break on it, other projects have scenarios where the dependency graph fails for not finding System.Enum in the definition catalog.