### PR TITLE
Parent objects should contain a reference counter

### DIFF
--- a/Dntc.Cli/Transpiler.cs
+++ b/Dntc.Cli/Transpiler.cs
@@ -5,6 +5,7 @@ using Dntc.Common.Conversion.Mutators;
 using Dntc.Common.Definitions;
 using Dntc.Common.Definitions.Definers;
 using Dntc.Common.Definitions.Mutators;
+using Dntc.Common.Definitions.ReferenceTypeSupport.ReferenceCounting;
 using Dntc.Common.Dependencies;
 using Dntc.Common.Planning;
 using Dntc.Common.Syntax.Statements.Generators;
@@ -84,7 +85,11 @@ public class Transpiler
         {
             conversionCatalog.Add(requiredType);
         }
-        
+
+        definitionCatalog.Add([new ReferenceCountingDefinedType()]);
+        definitionCatalog.Add([new ReferenceCountIncrementMethod()]);
+        definitionCatalog.Add([new ReferenceCounterField()]);
+
         var planConverter = new PlannedFileConverter(conversionCatalog, definitionCatalog, false);
         planConverter.AddInstructionGenerator(new DebugInfoStatementGenerator(_manifest.DebugInfoMode));
         definitionCatalog.Add(modules.SelectMany(x => x.Types)); // adding types via type definition automatically adds its methods

--- a/Dntc.Common/Definitions/DefinitionCatalog.cs
+++ b/Dntc.Common/Definitions/DefinitionCatalog.cs
@@ -45,6 +45,14 @@ public class DefinitionCatalog
         }
     }
 
+    public void Add(IEnumerable<DefinedField> fields)
+    {
+        foreach (var field in fields)
+        {
+            Add(field);
+        }
+    }
+
     public DefinedType? Get(IlTypeName ilName)
     {
         return _types.GetValueOrDefault(ilName);

--- a/Dntc.Common/Definitions/ReferenceTypeSupport/ReferenceCounting/ReferenceCountConstants.cs
+++ b/Dntc.Common/Definitions/ReferenceTypeSupport/ReferenceCounting/ReferenceCountConstants.cs
@@ -1,0 +1,13 @@
+namespace Dntc.Common.Definitions.ReferenceTypeSupport.ReferenceCounting;
+
+public static class ReferenceCountConstants
+{
+    public const string IlNamespace = "Dntc.System";
+    public const string HeaderFileName = "dntc.h";
+    public const string SourceFileName = "dntc.c";
+    public const string CounterIlTypeName = $"{IlNamespace}.ReferenceCounter";
+    public const string CounterTypeNativeName = "dntc_reference_counter";
+    public const string CountFieldName = "currentCount";
+    public const string IncrementMethodIlName = $"System.Void {IlNamespace}.ReferenceCounter.Increment()";
+    public const string IncrementMethodNativeName = "dntc_reference_counter_increment";
+}

--- a/Dntc.Common/Definitions/ReferenceTypeSupport/ReferenceCounting/ReferenceCountConstants.cs
+++ b/Dntc.Common/Definitions/ReferenceTypeSupport/ReferenceCounting/ReferenceCountConstants.cs
@@ -2,12 +2,14 @@ namespace Dntc.Common.Definitions.ReferenceTypeSupport.ReferenceCounting;
 
 public static class ReferenceCountConstants
 {
-    public const string IlNamespace = "Dntc.System";
-    public const string HeaderFileName = "dntc.h";
-    public const string SourceFileName = "dntc.c";
-    public const string CounterIlTypeName = $"{IlNamespace}.ReferenceCounter";
-    public const string CounterTypeNativeName = "dntc_reference_counter";
-    public const string CountFieldName = "currentCount";
-    public const string IncrementMethodIlName = $"System.Void {IlNamespace}.ReferenceCounter.Increment()";
-    public const string IncrementMethodNativeName = "dntc_reference_counter_increment";
+    public static IlNamespace IlNamespace = new("Dntc.System");
+    public static HeaderName HeaderFileName = new("dntc.h");
+    public static CSourceFileName SourceFileName = new("dntc.c");
+    public static IlTypeName CounterIlTypeName = new($"{IlNamespace}.ReferenceCounter");
+    public static CTypeName CounterTypeNativeName = new("dntc_reference_counter");
+    public static IlFieldId CounterIlFieldId = new($"{CounterIlTypeName} {IlNamespace}::ReferenceCounter");
+    public static CFieldName CounterFieldName = new("referenceCounter");
+    public static CFieldName CurrentCountFieldName = new("currentCount");
+    public static IlMethodId IncrementMethodIlName = new ($"System.Void {IlNamespace}.ReferenceCounter.Increment()");
+    public static CFunctionName IncrementMethodNativeName = new("dntc_reference_counter_increment");
 }

--- a/Dntc.Common/Definitions/ReferenceTypeSupport/ReferenceCounting/ReferenceCountIncrementMethod.cs
+++ b/Dntc.Common/Definitions/ReferenceTypeSupport/ReferenceCounting/ReferenceCountIncrementMethod.cs
@@ -1,0 +1,21 @@
+namespace Dntc.Common.Definitions.ReferenceTypeSupport.ReferenceCounting;
+
+/// <summary>
+/// Manages incrementing the reference
+/// </summary>
+public class ReferenceCountIncrementMethod : CustomDefinedMethod
+{
+    public ReferenceCountIncrementMethod()
+        : base(
+            new IlMethodId(ReferenceCountConstants.IncrementMethodIlName),
+            new IlTypeName(typeof(void).FullName!),
+            new IlNamespace(ReferenceCountConstants.IlNamespace),
+            new HeaderName(ReferenceCountConstants.HeaderFileName),
+            new CSourceFileName(ReferenceCountConstants.SourceFileName),
+            new CFunctionName(ReferenceCountConstants.IncrementMethodNativeName),
+            [
+                new Parameter(new IlTypeName(ReferenceCountConstants.CounterIlTypeName))],
+            hasImplementation)
+    {
+    }
+}

--- a/Dntc.Common/Definitions/ReferenceTypeSupport/ReferenceCounting/ReferenceCountIncrementMethod.cs
+++ b/Dntc.Common/Definitions/ReferenceTypeSupport/ReferenceCounting/ReferenceCountIncrementMethod.cs
@@ -1,21 +1,37 @@
+using Dntc.Common.Conversion;
+using Dntc.Common.Syntax.Statements;
+
 namespace Dntc.Common.Definitions.ReferenceTypeSupport.ReferenceCounting;
 
 /// <summary>
-/// Manages incrementing the reference
+/// Manages incrementing the reference count for a ref counter
 /// </summary>
 public class ReferenceCountIncrementMethod : CustomDefinedMethod
 {
     public ReferenceCountIncrementMethod()
         : base(
-            new IlMethodId(ReferenceCountConstants.IncrementMethodIlName),
+            ReferenceCountConstants.IncrementMethodIlName,
             new IlTypeName(typeof(void).FullName!),
-            new IlNamespace(ReferenceCountConstants.IlNamespace),
-            new HeaderName(ReferenceCountConstants.HeaderFileName),
-            new CSourceFileName(ReferenceCountConstants.SourceFileName),
-            new CFunctionName(ReferenceCountConstants.IncrementMethodNativeName),
+            ReferenceCountConstants.IlNamespace,
+            ReferenceCountConstants.HeaderFileName,
+            ReferenceCountConstants.SourceFileName,
+            ReferenceCountConstants.IncrementMethodNativeName,
             [
-                new Parameter(new IlTypeName(ReferenceCountConstants.CounterIlTypeName))],
-            hasImplementation)
+                new Parameter(ReferenceCountConstants.CounterIlTypeName, "refCounter", true)
+            ])
     {
+    }
+
+    public override CustomCodeStatementSet? GetCustomDeclaration()
+    {
+        return new CustomCodeStatementSet(
+            $"void ${NativeName}({ReferenceCountConstants.CounterIlTypeName}* refCounter)");
+    }
+
+    public override CStatementSet? GetCustomImplementation(ConversionCatalog catalog)
+    {
+        return new CustomCodeStatementSet($@"
+    refCounter->{ReferenceCountConstants.CurrentCountFieldName}++;
+");
     }
 }

--- a/Dntc.Common/Definitions/ReferenceTypeSupport/ReferenceCounting/ReferenceCounterField.cs
+++ b/Dntc.Common/Definitions/ReferenceTypeSupport/ReferenceCounting/ReferenceCounterField.cs
@@ -1,0 +1,24 @@
+using Dntc.Common.Syntax.Statements;
+
+namespace Dntc.Common.Definitions.ReferenceTypeSupport.ReferenceCounting;
+
+public class ReferenceCounterField : CustomDefinedField
+{
+    public ReferenceCounterField()
+        : base(
+            null,
+            null,
+            null,
+            ReferenceCountConstants.CounterFieldName,
+            ReferenceCountConstants.CounterIlFieldId,
+            ReferenceCountConstants.CounterIlTypeName,
+            false,
+            [])
+    {
+    }
+
+    public override CustomCodeStatementSet GetCustomDeclaration()
+    {
+        return new CustomCodeStatementSet($"{ReferenceCountConstants.CounterTypeNativeName} {NativeName}");
+    }
+}

--- a/Dntc.Common/Definitions/ReferenceTypeSupport/ReferenceCounting/ReferenceCountingDefinedType.cs
+++ b/Dntc.Common/Definitions/ReferenceTypeSupport/ReferenceCounting/ReferenceCountingDefinedType.cs
@@ -10,10 +10,10 @@ public class ReferenceCountingDefinedType : CustomDefinedType
 {
     public ReferenceCountingDefinedType()
         : base(
-            new IlTypeName(ReferenceCountConstants.CounterIlTypeName),
-            new HeaderName(ReferenceCountConstants.HeaderFileName),
-            new CSourceFileName(ReferenceCountConstants.SourceFileName),
-            new CTypeName(ReferenceCountConstants.CounterTypeNativeName),
+            ReferenceCountConstants.CounterIlTypeName,
+            ReferenceCountConstants.HeaderFileName,
+            ReferenceCountConstants.SourceFileName,
+            ReferenceCountConstants.CounterTypeNativeName,
             [
                 new IlTypeName(typeof(int).FullName!),
             ],
@@ -25,7 +25,7 @@ public class ReferenceCountingDefinedType : CustomDefinedType
     {
         return new CustomCodeStatementSet($@"
 typedef struct {NativeName} {{
-    int {ReferenceCountConstants.CountFieldName};
+    int {ReferenceCountConstants.CurrentCountFieldName};
 }} {NativeName};
 ");
     }

--- a/Dntc.Common/Definitions/ReferenceTypeSupport/ReferenceCounting/ReferenceCountingDefinedType.cs
+++ b/Dntc.Common/Definitions/ReferenceTypeSupport/ReferenceCounting/ReferenceCountingDefinedType.cs
@@ -1,0 +1,32 @@
+using Dntc.Common.Conversion;
+using Dntc.Common.Syntax.Statements;
+
+namespace Dntc.Common.Definitions.ReferenceTypeSupport.ReferenceCounting;
+
+/// <summary>
+/// Type that tracks reference count information. Does not support cyclic references, nor is it thread safe.
+/// </summary>
+public class ReferenceCountingDefinedType : CustomDefinedType
+{
+    public ReferenceCountingDefinedType()
+        : base(
+            new IlTypeName(ReferenceCountConstants.CounterIlTypeName),
+            new HeaderName(ReferenceCountConstants.HeaderFileName),
+            new CSourceFileName(ReferenceCountConstants.SourceFileName),
+            new CTypeName(ReferenceCountConstants.CounterTypeNativeName),
+            [
+                new IlTypeName(typeof(int).FullName!),
+            ],
+            [])
+    {
+    }
+
+    public override CustomCodeStatementSet? GetCustomTypeDeclaration(ConversionCatalog catalog)
+    {
+        return new CustomCodeStatementSet($@"
+typedef struct {NativeName} {{
+    int {ReferenceCountConstants.CountFieldName};
+}} {NativeName};
+");
+    }
+}

--- a/Dntc.Common/Syntax/TypeDeclaration.cs
+++ b/Dntc.Common/Syntax/TypeDeclaration.cs
@@ -50,6 +50,17 @@ public record TypeDeclaration(TypeConversionInfo TypeConversion, DefinedType Typ
             }
         }
 
+        // Write all the fields.
+        foreach (var field in dotNetDefinedType.InstanceFields)
+        {
+            var declaration = new FieldDeclaration(
+                Catalog.Find(field.Id),
+                FieldDeclaration.FieldFlags.IgnoreValueInitialization);
+
+            await writer.WriteAsync("\t");
+            await declaration.WriteAsync(writer);
+        }
+
         // Write the virtual table for virtual methods.
         var virtualMethodCount = 0;
         if (!dotNetDefinedType.Definition.IsValueType)
@@ -79,19 +90,6 @@ public record TypeDeclaration(TypeConversionInfo TypeConversion, DefinedType Typ
 
                 await writer.WriteLineAsync(");");
             }
-        }
-
-        // TODO Write the interface methods union vtables.
-        
-        // Write all the fields.
-        foreach (var field in dotNetDefinedType.InstanceFields)
-        {
-            var declaration = new FieldDeclaration(
-                Catalog.Find(field.Id),
-                FieldDeclaration.FieldFlags.IgnoreValueInitialization);
-
-            await writer.WriteAsync("\t");
-            await declaration.WriteAsync(writer);
         }
 
         if (dotNetDefinedType.InstanceFields.Count == 0 && virtualMethodCount == 0)

--- a/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp_ReferenceTypes.h
+++ b/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp_ReferenceTypes.h
@@ -5,10 +5,12 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include "dntc.h"
 
 typedef struct ScratchpadCSharp_ReferenceTypes_BasicClassSupportTests_ParentBase {
-	int32_t (*ScratchpadCSharp_ReferenceTypes_BasicClassSupportTests_ParentBase_Sum)(struct ScratchpadCSharp_ReferenceTypes_BasicClassSupportTests_ParentBase* __this, int32_t a, int32_t b);
+	dntc_reference_counter referenceCounter;
 	int32_t BaseField;
+	int32_t (*ScratchpadCSharp_ReferenceTypes_BasicClassSupportTests_ParentBase_Sum)(struct ScratchpadCSharp_ReferenceTypes_BasicClassSupportTests_ParentBase* __this, int32_t a, int32_t b);
 } ScratchpadCSharp_ReferenceTypes_BasicClassSupportTests_ParentBase;
 
 typedef struct ScratchpadCSharp_ReferenceTypes_BasicClassSupportTests_Parent {

--- a/Samples/Scratchpad/scratchpad_c/generated/dntc.h
+++ b/Samples/Scratchpad/scratchpad_c/generated/dntc.h
@@ -1,0 +1,15 @@
+#ifndef DNTC_H_H
+#define DNTC_H_H
+
+
+#include <stdint.h>
+
+
+typedef struct dntc_reference_counter {
+    int currentCount;
+} dntc_reference_counter;
+
+
+
+
+#endif // DNTC_H_H


### PR DESCRIPTION
To support reference counting, transpiled classes should have a reference counter on their base class. This should allow casting them into a reference counter for incrementing and decrementing.