### PR TITLE
Add function to untrack dotnet reference types

### DIFF
--- a/Dntc.Cli/Transpiler.cs
+++ b/Dntc.Cli/Transpiler.cs
@@ -33,8 +33,9 @@ public class Transpiler
         var plugins = LoadPlugins();
         var modules = GetModules();
         var charArrayType = modules.First().ImportReference(typeof(char[]));
+        var memoryManagement = new StandardMemoryManagementActions();
         
-        var transpilerPipeline = new TranspilerContext();
+        var transpilerPipeline = new TranspilerContext(memoryManagement);
         var definerPipeline = transpilerPipeline.Definers;
         var conversionInfoCreator = transpilerPipeline.ConversionInfoCreator;
         var definitionCatalog = transpilerPipeline.DefinitionCatalog;
@@ -95,7 +96,7 @@ public class Transpiler
         refCountImplementation.UpdateCatalog(definitionCatalog);
         refCountImplementation.AddFieldsToReferenceTypeBase(referenceTypeBaseDefinition);
 
-        var planConverter = new PlannedFileConverter(conversionCatalog, definitionCatalog, false);
+        var planConverter = new PlannedFileConverter(conversionCatalog, definitionCatalog, false, memoryManagement);
         planConverter.AddInstructionGenerator(new DebugInfoStatementGenerator(_manifest.DebugInfoMode));
         definitionCatalog.Add(modules.SelectMany(x => x.Types)); // adding types via type definition automatically adds its methods
 

--- a/Dntc.Common/Conversion/PlannedFileConverter.cs
+++ b/Dntc.Common/Conversion/PlannedFileConverter.cs
@@ -1,5 +1,6 @@
 ﻿using Dntc.Common.Conversion.Mutators;
 using Dntc.Common.Definitions;
+using Dntc.Common.Definitions.ReferenceTypeSupport;
 using Dntc.Common.OpCodeHandling;
 using Dntc.Common.Planning;
 using Dntc.Common.Syntax;
@@ -15,16 +16,19 @@ public class PlannedFileConverter
     private readonly ConversionCatalog _conversionCatalog;
     private readonly DefinitionCatalog _definitionCatalog;
     private readonly List<IStatementGenerator> _statementGenerators = [];
-    private readonly bool _debugLogging; 
+    private readonly bool _debugLogging;
+    private readonly IMemoryManagementActions _memoryManagement;
 
     public PlannedFileConverter(
         ConversionCatalog conversionCatalog, 
         DefinitionCatalog definitionCatalog, 
-        bool debugLogging)
+        bool debugLogging,
+        IMemoryManagementActions memoryManagement)
     {
         _conversionCatalog = conversionCatalog;
         _definitionCatalog = definitionCatalog;
         _debugLogging = debugLogging;
+        _memoryManagement = memoryManagement;
     }
 
     public HeaderFile Convert(PlannedHeaderFile plannedHeaderFile)
@@ -178,7 +182,8 @@ public class PlannedFileConverter
                     conversionInfo,
                     dotNetDefinedMethod,
                     _conversionCatalog,
-                    _definitionCatalog));
+                    _definitionCatalog,
+                    _memoryManagement));
             }
             catch (Exception exception)
             {

--- a/Dntc.Common/Conversion/PlannedFileConverter.cs
+++ b/Dntc.Common/Conversion/PlannedFileConverter.cs
@@ -172,6 +172,13 @@ public class PlannedFileConverter
                 throw new InvalidOperationException(message);
             }
 
+            var referenceTypeLocalVariables = statements
+                .Flatten()
+                .OfType<LocalDeclarationStatementSet>()
+                .Select(x => x.Variable)
+                .Where(x => x.Type.IsReferenceType)
+                .ToArray();
+
             var startStackSize = expressionStack.Count;
             OpCodeHandlingResult result;
             try
@@ -183,7 +190,8 @@ public class PlannedFileConverter
                     dotNetDefinedMethod,
                     _conversionCatalog,
                     _definitionCatalog,
-                    _memoryManagement));
+                    _memoryManagement,
+                    referenceTypeLocalVariables));
             }
             catch (Exception exception)
             {

--- a/Dntc.Common/Definitions/CustomDefinedMethods/ReferenceTypeAllocationMethod.cs
+++ b/Dntc.Common/Definitions/CustomDefinedMethods/ReferenceTypeAllocationMethod.cs
@@ -18,9 +18,9 @@ namespace Dntc.Common.Definitions.CustomDefinedMethods;
 public class ReferenceTypeAllocationMethod : CustomDefinedMethod
 {
     private readonly TypeDefinition _typeDefinition;
-    private readonly IMemoryManagementActions _memoryManagement = new StandardMemoryManagementActions();
+    private readonly IMemoryManagementActions _memoryManagement;
 
-    public ReferenceTypeAllocationMethod(TypeDefinition typeDefinition) 
+    public ReferenceTypeAllocationMethod(IMemoryManagementActions memoryManagement, TypeDefinition typeDefinition)
         :  base(new IlMethodId(typeDefinition.FullName + "__Create"),
             new IlTypeName(typeDefinition.FullName),
             Utils.GetNamespace(typeDefinition),
@@ -29,7 +29,8 @@ public class ReferenceTypeAllocationMethod : CustomDefinedMethod
             new CFunctionName(Utils.MakeValidCName(typeDefinition.FullName + "__Create")), [])
     {
         _typeDefinition = typeDefinition;
-        ReferencedHeaders = _memoryManagement.RequiredHeaders;
+        _memoryManagement = memoryManagement;
+        ReferencedHeaders = memoryManagement.RequiredHeaders;
 
         foreach (var virtualMethod in _typeDefinition.Methods.Where(x => x.IsVirtual))
         {

--- a/Dntc.Common/Definitions/DefinedMethod.cs
+++ b/Dntc.Common/Definitions/DefinedMethod.cs
@@ -19,6 +19,8 @@ public abstract class DefinedMethod
     
     // We don't want to bother analyzing methods we aren't going to transpile, so only analyze
     // if we enter a code path looking for globals, types, and other methods this method utilizes.
+    //
+    // We need this to be virtual so that we can hook into it for lazy analysis for .net methods.
     public virtual List<InvokedMethod> InvokedMethods { get; } = [];
 
     /// <summary>

--- a/Dntc.Common/Definitions/Definers/DefaultDotNetMethodDefiner.cs
+++ b/Dntc.Common/Definitions/Definers/DefaultDotNetMethodDefiner.cs
@@ -1,3 +1,4 @@
+using Dntc.Common.Definitions.ReferenceTypeSupport;
 using Mono.Cecil;
 
 namespace Dntc.Common.Definitions.Definers;
@@ -7,8 +8,15 @@ namespace Dntc.Common.Definitions.Definers;
 /// </summary>
 public class DefaultDotNetMethodDefiner : IDotNetMethodDefiner
 {
+    private readonly IMemoryManagementActions _memoryManagement;
+
+    public DefaultDotNetMethodDefiner(IMemoryManagementActions memoryManagement)
+    {
+        _memoryManagement = memoryManagement;
+    }
+
     public DefinedMethod Define(MethodDefinition method)
     {
-        return new DotNetDefinedMethod(method);
+        return new DotNetDefinedMethod(method, _memoryManagement);
     }
 }

--- a/Dntc.Common/Definitions/Definers/DefinitionGenerationPipeline.cs
+++ b/Dntc.Common/Definitions/Definers/DefinitionGenerationPipeline.cs
@@ -1,4 +1,5 @@
 using Dntc.Common.Definitions.Mutators;
+using Dntc.Common.Definitions.ReferenceTypeSupport;
 using Mono.Cecil;
 
 namespace Dntc.Common.Definitions.Definers;
@@ -13,9 +14,11 @@ public class DefinitionGenerationPipeline
     private readonly List<IDotNetTypeDefiner> _typeDefiners = [];
     private readonly List<IFieldDefinitionMutator> _fieldMutators = [];
     private readonly List<IMethodDefinitionMutator> _methodMutators = [];
+    private readonly IMemoryManagementActions _memoryManagement;
 
-    public DefinitionGenerationPipeline()
+    public DefinitionGenerationPipeline(IMemoryManagementActions memoryManagement)
     {
+        _memoryManagement = memoryManagement;
         Reset();
     }
 
@@ -29,7 +32,7 @@ public class DefinitionGenerationPipeline
         _typeDefiners.Clear();
         
         _globalDefiners.Add(new DefaultFieldDefiner());
-        _methodDefiners.Add(new DefaultDotNetMethodDefiner());
+        _methodDefiners.Add(new DefaultDotNetMethodDefiner(_memoryManagement));
         _typeDefiners.Add(new DefaultTypeDefiner());
     }
 

--- a/Dntc.Common/Definitions/ReferenceTypeSupport/ReferenceTypeConstants.cs
+++ b/Dntc.Common/Definitions/ReferenceTypeSupport/ReferenceTypeConstants.cs
@@ -9,5 +9,6 @@ public class ReferenceTypeConstants
     public static CTypeName ReferenceTypeBaseName = new("DntcReferenceTypeBase");
     public static IlFieldId ReferenceTypeBaseFieldId = new($"{ReferenceTypeBaseId} {IlNamespace}::base");
     public static CFieldName ReferenceTypeBaseFieldName = new("__reference_type_base");
-    public static IlMethodId RcIncrementMethodId = new($"System.Void {ReferenceTypeBaseId}.RcIncrement");
+    public static IlMethodId GcTrackMethodId = new($"System.Void {ReferenceTypeBaseId}.GcTrack");
+    public static IlMethodId GcUntrackMethodId = new($"System.Void {ReferenceTypeBaseId}.GcUntrack");
 }

--- a/Dntc.Common/Definitions/ReferenceTypeSupport/SimpleReferenceCounting/RefCountTrackMethod.cs
+++ b/Dntc.Common/Definitions/ReferenceTypeSupport/SimpleReferenceCounting/RefCountTrackMethod.cs
@@ -3,16 +3,16 @@ using Dntc.Common.Syntax.Statements;
 
 namespace Dntc.Common.Definitions.ReferenceTypeSupport.SimpleReferenceCounting;
 
-public class RefCountIncrementMethod : CustomDefinedMethod
+public class RefCountTrackMethod : CustomDefinedMethod
 {
-    public RefCountIncrementMethod()
+    public RefCountTrackMethod()
         : base(
-            ReferenceTypeConstants.RcIncrementMethodId,
+            ReferenceTypeConstants.GcTrackMethodId,
             new IlTypeName(typeof(void).FullName!),
             ReferenceTypeConstants.IlNamespace,
             ReferenceTypeConstants.HeaderFileName,
             ReferenceTypeConstants.SourceFileName,
-            new CFunctionName("DntcReferenceTypeBase_Rc_Increment"),
+            new CFunctionName("DntcReferenceTypeBase_Gc_Track"),
             [
                 new Parameter(ReferenceTypeConstants.ReferenceTypeBaseId, "referenceType", true),
             ])

--- a/Dntc.Common/Definitions/ReferenceTypeSupport/SimpleReferenceCounting/RefCountTrackMethod.cs
+++ b/Dntc.Common/Definitions/ReferenceTypeSupport/SimpleReferenceCounting/RefCountTrackMethod.cs
@@ -1,11 +1,14 @@
 using Dntc.Common.Conversion;
+using Dntc.Common.OpCodeHandling;
 using Dntc.Common.Syntax.Statements;
 
 namespace Dntc.Common.Definitions.ReferenceTypeSupport.SimpleReferenceCounting;
 
 public class RefCountTrackMethod : CustomDefinedMethod
 {
-    public RefCountTrackMethod()
+    public sealed override List<InvokedMethod> InvokedMethods { get; } = [];
+
+    public RefCountTrackMethod(IMemoryManagementActions memoryManagement)
         : base(
             ReferenceTypeConstants.GcTrackMethodId,
             new IlTypeName(typeof(void).FullName!),
@@ -17,6 +20,11 @@ public class RefCountTrackMethod : CustomDefinedMethod
                 new Parameter(ReferenceTypeConstants.ReferenceTypeBaseId, "referenceType", true),
             ])
     {
+        // While untrack won't be called by track, we should include it as an invoked method so the
+        // dependency graph will pick it up. It's much easier to heuristically know that untrack is needed if
+        // track is needed.
+        InvokedMethods = [new CustomInvokedMethod(new RefCountUntrackMethod(memoryManagement))];
+        ReferencedHeaders = memoryManagement.RequiredHeaders;
     }
 
     public override CustomCodeStatementSet? GetCustomDeclaration()

--- a/Dntc.Common/Definitions/ReferenceTypeSupport/SimpleReferenceCounting/RefCountUntrackMethod.cs
+++ b/Dntc.Common/Definitions/ReferenceTypeSupport/SimpleReferenceCounting/RefCountUntrackMethod.cs
@@ -20,6 +20,7 @@ public class RefCountUntrackMethod : CustomDefinedMethod
             ])
     {
         _memoryManagement = memoryManagement;
+        ReferencedHeaders = memoryManagement.RequiredHeaders;
     }
 
     public override CustomCodeStatementSet? GetCustomDeclaration()
@@ -33,7 +34,7 @@ public class RefCountUntrackMethod : CustomDefinedMethod
         var intType = catalog.Find(new IlTypeName(typeof(int).FullName!));
         var statements = new List<CStatementSet>();
         statements.Add(new CustomCodeStatementSet($@"
-    {{ReferenceTypeConstants.ReferenceTypeBaseName}} singlePointerVariable = *referenceType;
+    {ReferenceTypeConstants.ReferenceTypeBaseName} *singlePointerVariable = *referenceType;
     {intType.NameInC} count = --(singlePointerVariable->{SimpleRefCountConstants.CurrentCountFieldName});
     if (count <= 0) {{
 "));
@@ -41,9 +42,8 @@ public class RefCountUntrackMethod : CustomDefinedMethod
         var variable = new Variable(referenceTypeInfo, "singlePointerVariable", true);
         statements.Add(_memoryManagement.FreeCall(variable, catalog));
 
-        statements.Add(new CustomCodeStatementSet($@"
-        referenceType = NULL;
-}}
+        statements.Add(new CustomCodeStatementSet($@"   referenceType = NULL;
+    }}
 "));
 
         return new CompoundStatementSet(statements);

--- a/Dntc.Common/Definitions/ReferenceTypeSupport/SimpleReferenceCounting/RefCountUntrackMethod.cs
+++ b/Dntc.Common/Definitions/ReferenceTypeSupport/SimpleReferenceCounting/RefCountUntrackMethod.cs
@@ -1,0 +1,51 @@
+using Dntc.Common.Conversion;
+using Dntc.Common.Syntax.Statements;
+
+namespace Dntc.Common.Definitions.ReferenceTypeSupport.SimpleReferenceCounting;
+
+public class RefCountUntrackMethod : CustomDefinedMethod
+{
+    private readonly IMemoryManagementActions _memoryManagement;
+
+    public RefCountUntrackMethod(IMemoryManagementActions memoryManagement)
+        : base(
+            ReferenceTypeConstants.GcUntrackMethodId,
+            new IlTypeName(typeof(void).FullName!),
+            ReferenceTypeConstants.IlNamespace,
+            ReferenceTypeConstants.HeaderFileName,
+            ReferenceTypeConstants.SourceFileName,
+            new CFunctionName("DntcReferenceTypeBase_Gc_Untrack"),
+            [
+                new Parameter(ReferenceTypeConstants.ReferenceTypeBaseId, "referenceType", true),
+            ])
+    {
+        _memoryManagement = memoryManagement;
+    }
+
+    public override CustomCodeStatementSet? GetCustomDeclaration()
+    {
+        return new CustomCodeStatementSet(
+            $"void {NativeName}({ReferenceTypeConstants.ReferenceTypeBaseName} **referenceType)");
+    }
+
+    public override CStatementSet? GetCustomImplementation(ConversionCatalog catalog)
+    {
+        var intType = catalog.Find(new IlTypeName(typeof(int).FullName!));
+        var statements = new List<CStatementSet>();
+        statements.Add(new CustomCodeStatementSet($@"
+    {{ReferenceTypeConstants.ReferenceTypeBaseName}} singlePointerVariable = *referenceType;
+    {intType.NameInC} count = --(singlePointerVariable->{SimpleRefCountConstants.CurrentCountFieldName});
+    if (count <= 0) {{
+"));
+        var referenceTypeInfo = catalog.Find(ReferenceTypeConstants.ReferenceTypeBaseId);
+        var variable = new Variable(referenceTypeInfo, "singlePointerVariable", true);
+        statements.Add(_memoryManagement.FreeCall(variable, catalog));
+
+        statements.Add(new CustomCodeStatementSet($@"
+        referenceType = NULL;
+}}
+"));
+
+        return new CompoundStatementSet(statements);
+    }
+}

--- a/Dntc.Common/Definitions/ReferenceTypeSupport/SimpleReferenceCounting/RefCountUntrackMethod.cs
+++ b/Dntc.Common/Definitions/ReferenceTypeSupport/SimpleReferenceCounting/RefCountUntrackMethod.cs
@@ -40,11 +40,12 @@ public class RefCountUntrackMethod : CustomDefinedMethod
 "));
         var referenceTypeInfo = catalog.Find(ReferenceTypeConstants.ReferenceTypeBaseId);
         var variable = new Variable(referenceTypeInfo, "singlePointerVariable", true);
+
+        statements.Add(new CustomCodeStatementSet("\t"));
         statements.Add(_memoryManagement.FreeCall(variable, catalog));
 
-        statements.Add(new CustomCodeStatementSet($@"   referenceType = NULL;
-    }}
-"));
+        statements.Add(new CustomCodeStatementSet("\t\t*referenceType = NULL;\n"));
+        statements.Add(new CustomCodeStatementSet("\t}\n"));
 
         return new CompoundStatementSet(statements);
     }

--- a/Dntc.Common/OpCodeHandling/Handlers/CallHandlers.cs
+++ b/Dntc.Common/OpCodeHandling/Handlers/CallHandlers.cs
@@ -97,20 +97,14 @@ public class CallHandlers : IOpCodeHandlerCollection
             var localDeclaration = new LocalDeclarationStatementSet(tempVariable);
             var assignment = new AssignmentStatementSet(tempVariableExpression, methodCallExpression);
 
-            var voidType = context.ConversionCatalog.Find(new IlTypeName(typeof(void).FullName!));
-            var incrementInfo = context.ConversionCatalog.Find(ReferenceTypeConstants.GcTrackMethodId);
-            var incrementFnExpression = new LiteralValueExpression(incrementInfo.NameInC.Value, voidType);
-            var incrementFnCall = new MethodCallExpression(
-                incrementFnExpression,
-                incrementInfo.Parameters,
-                [tempVariableExpression],
-                voidType);
-
-            var incrementStatement = new VoidExpressionStatementSet(incrementFnCall);
+            var statements = new List<CStatementSet>([localDeclaration, assignment]);
+            if (returnType.IsReferenceType)
+            {
+                statements.Add(new GcTrackFunctionCallStatement(tempVariableExpression, context.ConversionCatalog));
+            }
 
             context.ExpressionStack.Push(tempVariableExpression);
-            return new OpCodeHandlingResult(
-                new CompoundStatementSet([localDeclaration, assignment, incrementStatement]));
+            return new OpCodeHandlingResult(new CompoundStatementSet(statements));
         }
 
         // Otherwise we can just inline the method call.

--- a/Dntc.Common/OpCodeHandling/Handlers/MiscHandlers.cs
+++ b/Dntc.Common/OpCodeHandling/Handlers/MiscHandlers.cs
@@ -120,31 +120,18 @@ public class MiscHandlers : IOpCodeHandlerCollection
             var statements = new List<CStatementSet>();
             if (innerExpression?.ResultingType.IsReferenceType == true)
             {
-                var trackMethod = context.ConversionCatalog.Find(ReferenceTypeConstants.GcTrackMethodId);
-                var fnCall = new MethodCallExpression(
-                    new LiteralValueExpression(trackMethod.NameInC.Value, voidType),
-                    trackMethod.Parameters,
-                    [innerExpression],
-                    voidType);
-
-                statements.Add(new VoidExpressionStatementSet(fnCall));
+                statements.Add(new GcTrackFunctionCallStatement(innerExpression, context.ConversionCatalog));
             }
 
             // If any locals are .net reference types, we need to untrack them
             if (context.ReferenceTypeVariables.Any())
             {
-                var untrackMethod = context.ConversionCatalog.Find(ReferenceTypeConstants.GcUntrackMethodId);
                 foreach (var variable in context.ReferenceTypeVariables)
                 {
-                    var baseType = context.ConversionCatalog.Find(ReferenceTypeConstants.ReferenceTypeBaseId);
-                    var doublePointerVariable = new LiteralValueExpression($"({baseType.NameInC}**)&{variable.Name}", baseType);
-                    var fnCall = new MethodCallExpression(
-                        new LiteralValueExpression(untrackMethod.NameInC.Value, voidType),
-                        untrackMethod.Parameters,
-                        [doublePointerVariable],
-                        voidType);
-
-                    statements.Add(new VoidExpressionStatementSet(fnCall));
+                    statements.Add(
+                        new GcUntrackFunctionCallStatement(
+                            new VariableValueExpression(variable),
+                            context.ConversionCatalog));
                 }
             }
 

--- a/Dntc.Common/OpCodeHandling/IOpCodeHandler.cs
+++ b/Dntc.Common/OpCodeHandling/IOpCodeHandler.cs
@@ -12,7 +12,8 @@ public record HandleContext(
     DotNetDefinedMethod CurrentDotNetMethod,
     ConversionCatalog ConversionCatalog,
     DefinitionCatalog DefinitionCatalog,
-    IMemoryManagementActions MemoryManagementActions);
+    IMemoryManagementActions MemoryManagementActions,
+    IReadOnlyList<Variable> ReferenceTypeVariables);
 
 public record AnalyzeContext(
     Instruction CurrentInstruction,

--- a/Dntc.Common/OpCodeHandling/IOpCodeHandler.cs
+++ b/Dntc.Common/OpCodeHandling/IOpCodeHandler.cs
@@ -1,5 +1,6 @@
 ﻿using Dntc.Common.Conversion;
 using Dntc.Common.Definitions;
+using Dntc.Common.Definitions.ReferenceTypeSupport;
 using Mono.Cecil.Cil;
 
 namespace Dntc.Common.OpCodeHandling;
@@ -10,9 +11,13 @@ public record HandleContext(
     MethodConversionInfo CurrentMethodConversion,
     DotNetDefinedMethod CurrentDotNetMethod,
     ConversionCatalog ConversionCatalog,
-    DefinitionCatalog DefinitionCatalog);
+    DefinitionCatalog DefinitionCatalog,
+    IMemoryManagementActions MemoryManagementActions);
 
-public record AnalyzeContext(Instruction CurrentInstruction, DotNetDefinedMethod CurrentMethod);
+public record AnalyzeContext(
+    Instruction CurrentInstruction,
+    DotNetDefinedMethod CurrentMethod,
+    IMemoryManagementActions MemoryManagementActions);
 
 public interface IOpCodeHandler
 {

--- a/Dntc.Common/Syntax/Statements/GcTrackFunctionCallStatement.cs
+++ b/Dntc.Common/Syntax/Statements/GcTrackFunctionCallStatement.cs
@@ -1,0 +1,27 @@
+using Dntc.Common.Conversion;
+using Dntc.Common.Definitions.ReferenceTypeSupport;
+using Dntc.Common.Syntax.Expressions;
+
+namespace Dntc.Common.Syntax.Statements;
+
+/// <summary>
+/// Statement that calls the required function to track specified object by the current
+/// garbage collection implementation.
+/// </summary>
+/// <param name="VariableToIncrement">Expression containing the object to track</param>
+/// <param name="Catalog"></param>
+public record GcTrackFunctionCallStatement(
+    CBaseExpression VariableToIncrement,
+    ConversionCatalog Catalog)
+    : CStatementSet
+{
+    public override async Task WriteAsync(StreamWriter writer)
+    {
+        var baseType = Catalog.Find(ReferenceTypeConstants.ReferenceTypeBaseId);
+        var incrementInfo = Catalog.Find(ReferenceTypeConstants.GcTrackMethodId);
+
+        await writer.WriteAsync($"\t{incrementInfo.NameInC}(({baseType.NameInC}*)");
+        await VariableToIncrement.WriteCodeStringAsync(writer);
+        await writer.WriteLineAsync(");");
+    }
+}

--- a/Dntc.Common/Syntax/Statements/GcUntrackFunctionCallStatement.cs
+++ b/Dntc.Common/Syntax/Statements/GcUntrackFunctionCallStatement.cs
@@ -1,0 +1,21 @@
+using Dntc.Common.Conversion;
+using Dntc.Common.Definitions.ReferenceTypeSupport;
+using Dntc.Common.Syntax.Expressions;
+
+namespace Dntc.Common.Syntax.Statements;
+
+public record GcUntrackFunctionCallStatement(
+    CBaseExpression VariableToUntrack,
+    ConversionCatalog Catalog)
+    : CStatementSet
+{
+    public override async Task WriteAsync(StreamWriter writer)
+    {
+        var untrackMethod = Catalog.Find(ReferenceTypeConstants.GcUntrackMethodId);
+        var baseType = Catalog.Find(ReferenceTypeConstants.ReferenceTypeBaseId);
+
+        await writer.WriteAsync($"\t{untrackMethod.NameInC}(({baseType.NameInC}**)&");
+        await VariableToUntrack.WriteCodeStringAsync(writer);
+        await writer.WriteLineAsync(");");
+    }
+}

--- a/Dntc.Common/Syntax/SyntaxExtensions.cs
+++ b/Dntc.Common/Syntax/SyntaxExtensions.cs
@@ -1,0 +1,22 @@
+using Dntc.Common.Syntax.Statements;
+
+namespace Dntc.Common.Syntax;
+
+public static class SyntaxExtensions
+{
+    public static IEnumerable<CStatementSet> Flatten(this IEnumerable<CStatementSet> statements)
+    {
+        foreach (var statement in statements)
+        {
+            if (statement is CompoundStatementSet compound)
+            {
+                foreach (var innerStatement in compound.Flatten())
+                {
+                    yield return innerStatement;
+                }
+            }
+
+            yield return statement;
+        }
+    }
+}

--- a/Dntc.Common/TranspilerContext.cs
+++ b/Dntc.Common/TranspilerContext.cs
@@ -1,6 +1,7 @@
 using Dntc.Common.Conversion;
 using Dntc.Common.Definitions;
 using Dntc.Common.Definitions.Definers;
+using Dntc.Common.Definitions.ReferenceTypeSupport;
 
 namespace Dntc.Common;
 
@@ -11,9 +12,9 @@ public class TranspilerContext
     public DefinitionCatalog DefinitionCatalog { get; }
     public ConversionCatalog ConversionCatalog { get; }
 
-    public TranspilerContext()
+    public TranspilerContext(IMemoryManagementActions memoryManagement)
     {
-        Definers = new DefinitionGenerationPipeline();
+        Definers = new DefinitionGenerationPipeline(memoryManagement);
         ConversionInfoCreator = new ConversionInfoCreator();
         DefinitionCatalog = new DefinitionCatalog(Definers);
         ConversionCatalog = new ConversionCatalog(DefinitionCatalog, ConversionInfoCreator);

--- a/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.c
+++ b/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.c
@@ -403,7 +403,6 @@ int32_t ScratchpadCSharp_AttributeTests_GetCustomDeclaredField(ScratchpadCSharp_
 int32_t* ScratchpadCSharp_GenericTests_GenericPointerTest(void) {
 	int32_t* __temp_000f = {0};
 	__temp_000f = generic_pointer_return_type_test(sizeof(int32_t));
-	DntcReferenceTypeBase_Gc_Track((DntcReferenceTypeBase*)__temp_000f);
 	(*__temp_000f) = 25;
 	return __temp_000f;
 }
@@ -422,13 +421,10 @@ void ScratchpadCSharp_GenericTests_PointerAssignmentTest(int32_t *input) {
 	int32_t* __temp_0025 = {0};
 	int32_t* __temp_003a = {0};
 	__temp_000f = generic_pointer_return_type_test(sizeof(int32_t));
-	DntcReferenceTypeBase_Gc_Track((DntcReferenceTypeBase*)__temp_000f);
 	input = __temp_000f;
 	__temp_0025 = generic_pointer_return_type_test(sizeof(int32_t));
-	DntcReferenceTypeBase_Gc_Track((DntcReferenceTypeBase*)__temp_0025);
 	first = __temp_0025;
 	__temp_003a = generic_pointer_return_type_test(sizeof(int32_t));
-	DntcReferenceTypeBase_Gc_Track((DntcReferenceTypeBase*)__temp_003a);
 	second = __temp_003a;
 	(*input) = ((*first) + (*second));
 	return;
@@ -437,14 +433,12 @@ void ScratchpadCSharp_GenericTests_PointerAssignmentTest(int32_t *input) {
 bool ScratchpadCSharp_GenericTests_PointerNullCheck(void) {
 	ScratchpadCSharp_GenericTests_SimpleStruct* __temp_000f = {0};
 	__temp_000f = generic_pointer_return_type_test(sizeof(ScratchpadCSharp_GenericTests_SimpleStruct));
-	DntcReferenceTypeBase_Gc_Track((DntcReferenceTypeBase*)__temp_000f);
 	return (__temp_000f == ((uint32_t)0));
 }
 
 int32_t ScratchpadCSharp_GenericTests_PointerNullCheck2(void) {
 	ScratchpadCSharp_GenericTests_SimpleStruct* __temp_000f = {0};
 	__temp_000f = generic_pointer_return_type_test(sizeof(ScratchpadCSharp_GenericTests_SimpleStruct));
-	DntcReferenceTypeBase_Gc_Track((DntcReferenceTypeBase*)__temp_000f);
 	if ((__temp_000f == ((uint32_t)0))) {
 		goto ScratchpadCSharp_GenericTests_PointerNullCheck2_IL_001a;
 	}

--- a/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.c
+++ b/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp.c
@@ -403,6 +403,7 @@ int32_t ScratchpadCSharp_AttributeTests_GetCustomDeclaredField(ScratchpadCSharp_
 int32_t* ScratchpadCSharp_GenericTests_GenericPointerTest(void) {
 	int32_t* __temp_000f = {0};
 	__temp_000f = generic_pointer_return_type_test(sizeof(int32_t));
+	DntcReferenceTypeBase_Gc_Track((DntcReferenceTypeBase*)__temp_000f);
 	(*__temp_000f) = 25;
 	return __temp_000f;
 }
@@ -421,10 +422,13 @@ void ScratchpadCSharp_GenericTests_PointerAssignmentTest(int32_t *input) {
 	int32_t* __temp_0025 = {0};
 	int32_t* __temp_003a = {0};
 	__temp_000f = generic_pointer_return_type_test(sizeof(int32_t));
+	DntcReferenceTypeBase_Gc_Track((DntcReferenceTypeBase*)__temp_000f);
 	input = __temp_000f;
 	__temp_0025 = generic_pointer_return_type_test(sizeof(int32_t));
+	DntcReferenceTypeBase_Gc_Track((DntcReferenceTypeBase*)__temp_0025);
 	first = __temp_0025;
 	__temp_003a = generic_pointer_return_type_test(sizeof(int32_t));
+	DntcReferenceTypeBase_Gc_Track((DntcReferenceTypeBase*)__temp_003a);
 	second = __temp_003a;
 	(*input) = ((*first) + (*second));
 	return;
@@ -433,12 +437,14 @@ void ScratchpadCSharp_GenericTests_PointerAssignmentTest(int32_t *input) {
 bool ScratchpadCSharp_GenericTests_PointerNullCheck(void) {
 	ScratchpadCSharp_GenericTests_SimpleStruct* __temp_000f = {0};
 	__temp_000f = generic_pointer_return_type_test(sizeof(ScratchpadCSharp_GenericTests_SimpleStruct));
+	DntcReferenceTypeBase_Gc_Track((DntcReferenceTypeBase*)__temp_000f);
 	return (__temp_000f == ((uint32_t)0));
 }
 
 int32_t ScratchpadCSharp_GenericTests_PointerNullCheck2(void) {
 	ScratchpadCSharp_GenericTests_SimpleStruct* __temp_000f = {0};
 	__temp_000f = generic_pointer_return_type_test(sizeof(ScratchpadCSharp_GenericTests_SimpleStruct));
+	DntcReferenceTypeBase_Gc_Track((DntcReferenceTypeBase*)__temp_000f);
 	if ((__temp_000f == ((uint32_t)0))) {
 		goto ScratchpadCSharp_GenericTests_PointerNullCheck2_IL_001a;
 	}

--- a/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp_ReferenceTypes.c
+++ b/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp_ReferenceTypes.c
@@ -34,8 +34,10 @@ void ScratchpadCSharp_ReferenceTypes_BasicClassSupportTests_Parent__ctor(Scratch
 ScratchpadCSharp_ReferenceTypes_BasicClassSupportTests_Parent* ScratchpadCSharp_ReferenceTypes_BasicClassSupportTests_CreateParent(int32_t value) {
 	ScratchpadCSharp_ReferenceTypes_BasicClassSupportTests_Parent* __temp_0001 = {0};
 	__temp_0001 = ScratchpadCSharp_ReferenceTypes_BasicClassSupportTests_Parent__Create();
-	DntcReferenceTypeBase_Rc_Increment((DntcReferenceTypeBase*)__temp_0001);
+	DntcReferenceTypeBase_Gc_Track((DntcReferenceTypeBase*)__temp_0001);
 	ScratchpadCSharp_ReferenceTypes_BasicClassSupportTests_Parent__ctor(__temp_0001, value);
+	DntcReferenceTypeBase_Gc_Track((DntcReferenceTypeBase*)__temp_0001);
+	DntcReferenceTypeBase_Gc_Untrack((DntcReferenceTypeBase**)&__temp_0001);
 	return __temp_0001;
 }
 
@@ -48,6 +50,8 @@ int32_t ScratchpadCSharp_ReferenceTypes_BasicClassSupportTests_GetParentValue(Sc
 int32_t ScratchpadCSharp_ReferenceTypes_BasicClassSupportTests_Test(void) {
 	ScratchpadCSharp_ReferenceTypes_BasicClassSupportTests_Parent* __temp_0002 = {0};
 	__temp_0002 = ScratchpadCSharp_ReferenceTypes_BasicClassSupportTests_CreateParent(10);
+	DntcReferenceTypeBase_Gc_Track((DntcReferenceTypeBase*)__temp_0002);
+	DntcReferenceTypeBase_Gc_Untrack((DntcReferenceTypeBase**)&__temp_0002);
 	return ScratchpadCSharp_ReferenceTypes_BasicClassSupportTests_GetParentValue(__temp_0002);
 }
 

--- a/Samples/Scratchpad/scratchpad_c/generated/dntc.c
+++ b/Samples/Scratchpad/scratchpad_c/generated/dntc.c
@@ -1,7 +1,18 @@
+#include <stdlib.h>
 #include "dntc.h"
 
 
-void DntcReferenceTypeBase_Rc_Increment(DntcReferenceTypeBase *referenceType) {
+void DntcReferenceTypeBase_Gc_Untrack(DntcReferenceTypeBase **referenceType) {
+
+    DntcReferenceTypeBase *singlePointerVariable = *referenceType;
+    int32_t count = --(singlePointerVariable->activeReferenceCount);
+    if (count <= 0) {
+	free(singlePointerVariable);
+   referenceType = NULL;
+    }
+}
+
+void DntcReferenceTypeBase_Gc_Track(DntcReferenceTypeBase *referenceType) {
 
     referenceType->activeReferenceCount++;
 }

--- a/Samples/Scratchpad/scratchpad_c/generated/dntc.c
+++ b/Samples/Scratchpad/scratchpad_c/generated/dntc.c
@@ -7,9 +7,9 @@ void DntcReferenceTypeBase_Gc_Untrack(DntcReferenceTypeBase **referenceType) {
     DntcReferenceTypeBase *singlePointerVariable = *referenceType;
     int32_t count = --(singlePointerVariable->activeReferenceCount);
     if (count <= 0) {
-	free(singlePointerVariable);
-   referenceType = NULL;
-    }
+		free(singlePointerVariable);
+		*referenceType = NULL;
+	}
 }
 
 void DntcReferenceTypeBase_Gc_Track(DntcReferenceTypeBase *referenceType) {

--- a/Samples/Scratchpad/scratchpad_c/generated/dntc.h
+++ b/Samples/Scratchpad/scratchpad_c/generated/dntc.h
@@ -3,6 +3,7 @@
 
 
 #include <stdint.h>
+#include <stdlib.h>
 
 typedef struct DntcReferenceTypeBase {
 	int32_t activeReferenceCount;
@@ -10,6 +11,7 @@ typedef struct DntcReferenceTypeBase {
 
 
 
-void DntcReferenceTypeBase_Rc_Increment(DntcReferenceTypeBase *referenceType);
+void DntcReferenceTypeBase_Gc_Untrack(DntcReferenceTypeBase **referenceType);
+void DntcReferenceTypeBase_Gc_Track(DntcReferenceTypeBase *referenceType);
 
 #endif // DNTC_H_H

--- a/Samples/Scratchpad/scratchpad_c/main.c
+++ b/Samples/Scratchpad/scratchpad_c/main.c
@@ -233,6 +233,17 @@ void validate_reference_counting() {
     ScratchpadCSharp_ReferenceTypes_BasicClassSupportTests_Parent* parent = ScratchpadCSharp_ReferenceTypes_BasicClassSupportTests_CreateParent(15);
     assert(parent->base.__reference_type_base.activeReferenceCount == 1);
 
+    // Verify tracking increments as expected
+    DntcReferenceTypeBase_Gc_Track((DntcReferenceTypeBase*)parent);
+    int32_t count1 = parent->base.__reference_type_base.activeReferenceCount;
+    assert(count1 == 2);
+
+    // Untracking decrements without nulling the pointer
+    DntcReferenceTypeBase_Gc_Untrack((DntcReferenceTypeBase**)&parent);
+    assert(parent != NULL);
+    int32_t count2 = parent->base.__reference_type_base.activeReferenceCount;
+    assert(count2 == 1);
+
     // Verify untracking nulls out the pointer
     DntcReferenceTypeBase_Gc_Untrack((DntcReferenceTypeBase**)&parent);
     assert(parent == NULL);

--- a/Samples/Scratchpad/scratchpad_c/main.c
+++ b/Samples/Scratchpad/scratchpad_c/main.c
@@ -232,4 +232,8 @@ void validate_reference_counting() {
     // Creation and return should have a single active reference count
     ScratchpadCSharp_ReferenceTypes_BasicClassSupportTests_Parent* parent = ScratchpadCSharp_ReferenceTypes_BasicClassSupportTests_CreateParent(15);
     assert(parent->base.__reference_type_base.activeReferenceCount == 1);
+
+    // Verify untracking nulls out the pointer
+    DntcReferenceTypeBase_Gc_Untrack((DntcReferenceTypeBase**)&parent);
+    assert(parent == NULL);
 }


### PR DESCRIPTION
Adds a new function that handles untracking an object from the garbage collection algorithm currently in place.  For the initial implementation this consists of decrementing the reference count and calling `free()` if the reference count drops to zero.

The function nulls out the caller's pointer as well, to prevent and discourage native C callers from calling it after its been freed.