### PR TITLE
Untracking a reference type should recursively prep reference type

### DIFF
--- a/Dntc.Common/Definitions/CustomDefinedMethods/ReferenceTypeAllocationMethod.cs
+++ b/Dntc.Common/Definitions/CustomDefinedMethods/ReferenceTypeAllocationMethod.cs
@@ -61,6 +61,22 @@ public class ReferenceTypeAllocationMethod : CustomDefinedMethod
             _memoryManagement.AllocateCall(variable, typeNameExpression, catalog)
         };
 
+        // Set the prep for free function pointer to the correct function
+        var referenceBaseTypeInfo = catalog.Find(ReferenceTypeConstants.ReferenceTypeBaseId);
+        var voidType = catalog.Find(new IlTypeName(typeof(void).FullName!));
+        var cast = new CastExpression(new VariableValueExpression(variable), referenceBaseTypeInfo, true);
+        var fnPointerAccess = new FieldAccessExpression(
+            cast,
+            new Variable(voidType, ReferenceTypeConstants.PrepForFreeFnPointerName.Value, false));
+
+        var prepFnInfo = catalog.Find(
+            ReferenceTypeConstants.PrepTypeToFreeMethodId(
+                new IlTypeName(_typeDefinition.FullName)));
+
+        var prepFnExpression = new LiteralValueExpression(prepFnInfo.NameInC.Value, voidType);
+        var assignment = new AssignmentStatementSet(fnPointerAccess, prepFnExpression);
+        statements.Add(assignment);
+
         var sb = new StringBuilder();
         foreach (var virtualMethod in _typeDefinition.Methods.Where(x => x.IsVirtual))
         {

--- a/Dntc.Common/Definitions/ReferenceTypeSupport/PrepToFreeDefinedMethod.cs
+++ b/Dntc.Common/Definitions/ReferenceTypeSupport/PrepToFreeDefinedMethod.cs
@@ -46,6 +46,8 @@ public class PrepToFreeDefinedMethod : CustomDefinedMethod
             statements.Add(
                 new CustomCodeStatementSet(
                     $"\t{untrackMethod.NameInC}(({ReferenceTypeConstants.ReferenceTypeBaseName}**)&object->{fieldInfo.NameInC});"));
+
+            statements.Add(new CustomCodeStatementSet("\n")); // Need to come up with a better white space strategy
         }
 
         var baseType = Utils.GetNonSystemBaseType(_dotNetType.Definition);

--- a/Dntc.Common/Definitions/ReferenceTypeSupport/PrepToFreeDefinedMethod.cs
+++ b/Dntc.Common/Definitions/ReferenceTypeSupport/PrepToFreeDefinedMethod.cs
@@ -39,14 +39,15 @@ public class PrepToFreeDefinedMethod : CustomDefinedMethod
             .Select(x => new IlFieldId(x.FullName))
             .ToArray();
 
-        var untrackMethod = catalog.Find(ReferenceTypeConstants.GcUntrackMethodId);
+        var thisTypeInfo = catalog.Find(_dotNetType.IlName);
+        var objectVariable = new Variable(thisTypeInfo, "object", true);
+        var objectVariableExpression = new VariableValueExpression(objectVariable);
         foreach (var field in referenceTypeFields)
         {
             var fieldInfo = catalog.Find(field);
-            statements.Add(
-                new CustomCodeStatementSet(
-                    $"\t{untrackMethod.NameInC}(({ReferenceTypeConstants.ReferenceTypeBaseName}**)&object->{fieldInfo.NameInC});"));
-
+            var fieldVariable = new Variable(fieldInfo.FieldTypeConversionInfo, fieldInfo.NameInC.Value, true);
+            var fieldAccess = new FieldAccessExpression(objectVariableExpression, fieldVariable);
+            statements.Add(new GcUntrackFunctionCallStatement(fieldAccess, catalog));
             statements.Add(new CustomCodeStatementSet("\n")); // Need to come up with a better white space strategy
         }
 

--- a/Dntc.Common/Definitions/ReferenceTypeSupport/ReferenceTypeBaseDefinedType.cs
+++ b/Dntc.Common/Definitions/ReferenceTypeSupport/ReferenceTypeBaseDefinedType.cs
@@ -32,6 +32,7 @@ public class ReferenceTypeBaseDefinedType : CustomDefinedType
     {
         var code = new StringBuilder();
         code.AppendLine($"typedef struct {NativeName} {{");
+        code.AppendLine($"void (*{ReferenceTypeConstants.PrepForFreeFnPointerName})(void* object);");
 
         foreach (var field in InstanceFields)
         {

--- a/Dntc.Common/Definitions/ReferenceTypeSupport/ReferenceTypeBaseDefinedType.cs
+++ b/Dntc.Common/Definitions/ReferenceTypeSupport/ReferenceTypeBaseDefinedType.cs
@@ -32,7 +32,7 @@ public class ReferenceTypeBaseDefinedType : CustomDefinedType
     {
         var code = new StringBuilder();
         code.AppendLine($"typedef struct {NativeName} {{");
-        code.AppendLine($"void (*{ReferenceTypeConstants.PrepForFreeFnPointerName})(void* object);");
+        code.AppendLine($"\tvoid (*{ReferenceTypeConstants.PrepForFreeFnPointerName})(void* object);");
 
         foreach (var field in InstanceFields)
         {

--- a/Dntc.Common/Definitions/ReferenceTypeSupport/ReferenceTypeConstants.cs
+++ b/Dntc.Common/Definitions/ReferenceTypeSupport/ReferenceTypeConstants.cs
@@ -11,6 +11,7 @@ public class ReferenceTypeConstants
     public static CFieldName ReferenceTypeBaseFieldName = new("__reference_type_base");
     public static IlMethodId GcTrackMethodId = new($"System.Void {ReferenceTypeBaseId}.GcTrack");
     public static IlMethodId GcUntrackMethodId = new($"System.Void {ReferenceTypeBaseId}.GcUntrack");
+    public static CFieldName PrepForFreeFnPointerName = new("PrepForFree");
 
     public static IlMethodId PrepTypeToFreeMethodId(IlTypeName typeToTrack)
     {

--- a/Dntc.Common/Definitions/ReferenceTypeSupport/SimpleReferenceCounting/RefCountUntrackMethod.cs
+++ b/Dntc.Common/Definitions/ReferenceTypeSupport/SimpleReferenceCounting/RefCountUntrackMethod.cs
@@ -41,6 +41,12 @@ public class RefCountUntrackMethod : CustomDefinedMethod
         var referenceTypeInfo = catalog.Find(ReferenceTypeConstants.ReferenceTypeBaseId);
         var variable = new Variable(referenceTypeInfo, "singlePointerVariable", true);
 
+        // TODO: Find a way to generalize this so it doesn't have to be manually included
+        // in every RC implementation.
+        statements.Add(
+            new CustomCodeStatementSet(
+                "\t\tsinglePointerVariable->PrepForFree(singlePointerVariable);\n"));
+
         statements.Add(new CustomCodeStatementSet("\t"));
         statements.Add(_memoryManagement.FreeCall(variable, catalog));
 

--- a/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp_ReferenceTypes.c
+++ b/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp_ReferenceTypes.c
@@ -25,7 +25,7 @@ int32_t ScratchpadCSharp_ReferenceTypes_BasicClassSupportTests_Parent_Sum(Scratc
 ScratchpadCSharp_ReferenceTypes_BasicClassSupportTests_Parent* ScratchpadCSharp_ReferenceTypes_BasicClassSupportTests_Parent__Create(void) {
 	ScratchpadCSharp_ReferenceTypes_BasicClassSupportTests_Parent* result = {0};
 	result = calloc(1, sizeof(ScratchpadCSharp_ReferenceTypes_BasicClassSupportTests_Parent));
-	(((DntcReferenceTypeBase*)result)->PrepForFree) = ScratchpadCSharp_ReferenceTypes_BasicClassSupportTests_Parent__PrepForFree;
+	(((DntcReferenceTypeBase*)result)->PrepForFree) = (void (*)(void*))ScratchpadCSharp_ReferenceTypes_BasicClassSupportTests_Parent__PrepForFree;
 	((ScratchpadCSharp_ReferenceTypes_BasicClassSupportTests_ParentBase*)result)->ScratchpadCSharp_ReferenceTypes_BasicClassSupportTests_ParentBase_Sum = (int32_t (*)(ScratchpadCSharp_ReferenceTypes_BasicClassSupportTests_ParentBase*, int32_t, int32_t))ScratchpadCSharp_ReferenceTypes_BasicClassSupportTests_Parent_Sum;
 	return result;
 }

--- a/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp_ReferenceTypes.c
+++ b/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp_ReferenceTypes.c
@@ -25,6 +25,7 @@ int32_t ScratchpadCSharp_ReferenceTypes_BasicClassSupportTests_Parent_Sum(Scratc
 ScratchpadCSharp_ReferenceTypes_BasicClassSupportTests_Parent* ScratchpadCSharp_ReferenceTypes_BasicClassSupportTests_Parent__Create(void) {
 	ScratchpadCSharp_ReferenceTypes_BasicClassSupportTests_Parent* result = {0};
 	result = calloc(1, sizeof(ScratchpadCSharp_ReferenceTypes_BasicClassSupportTests_Parent));
+	(((DntcReferenceTypeBase*)result)->PrepForFree) = ScratchpadCSharp_ReferenceTypes_BasicClassSupportTests_Parent__PrepForFree;
 	((ScratchpadCSharp_ReferenceTypes_BasicClassSupportTests_ParentBase*)result)->ScratchpadCSharp_ReferenceTypes_BasicClassSupportTests_ParentBase_Sum = (int32_t (*)(ScratchpadCSharp_ReferenceTypes_BasicClassSupportTests_ParentBase*, int32_t, int32_t))ScratchpadCSharp_ReferenceTypes_BasicClassSupportTests_Parent_Sum;
 	return result;
 }

--- a/Samples/Scratchpad/scratchpad_c/generated/dntc.c
+++ b/Samples/Scratchpad/scratchpad_c/generated/dntc.c
@@ -7,6 +7,7 @@ void DntcReferenceTypeBase_Gc_Untrack(DntcReferenceTypeBase **referenceType) {
     DntcReferenceTypeBase *singlePointerVariable = *referenceType;
     int32_t count = --(singlePointerVariable->activeReferenceCount);
     if (count <= 0) {
+		singlePointerVariable->PrepForFree(singlePointerVariable);
 		free(singlePointerVariable);
 		*referenceType = NULL;
 	}

--- a/Samples/Scratchpad/scratchpad_c/generated/dntc.h
+++ b/Samples/Scratchpad/scratchpad_c/generated/dntc.h
@@ -6,6 +6,7 @@
 #include <stdlib.h>
 
 typedef struct DntcReferenceTypeBase {
+void (*PrepForFree)(void* object);
 	int32_t activeReferenceCount;
 } DntcReferenceTypeBase;
 

--- a/Samples/Scratchpad/scratchpad_c/generated/dntc.h
+++ b/Samples/Scratchpad/scratchpad_c/generated/dntc.h
@@ -6,7 +6,7 @@
 #include <stdlib.h>
 
 typedef struct DntcReferenceTypeBase {
-void (*PrepForFree)(void* object);
+	void (*PrepForFree)(void* object);
 	int32_t activeReferenceCount;
 } DntcReferenceTypeBase;
 


### PR DESCRIPTION
When calling `UnTrack()` on a .net reference type, before we deallocate it we need to call `UnTrack()` on any reference type that the original untracked type has fields for. 

In order to accomplish this, the `ReferenceTypeBase` type needs a pointer to the `PrepForFree()` function for the specific reference type that the `ReferenceTypeBase` is attached to.  This function pointer is then invoked before deallocation to perform the correct preparations.