### PR TITLE
Fix transpiled ref type null check

### DIFF
--- a/Dntc.Common/Definitions/ReferenceTypeSupport/SimpleReferenceCounting/RefCountTrackMethod.cs
+++ b/Dntc.Common/Definitions/ReferenceTypeSupport/SimpleReferenceCounting/RefCountTrackMethod.cs
@@ -36,6 +36,7 @@ public class RefCountTrackMethod : CustomDefinedMethod
     public override CStatementSet? GetCustomImplementation(ConversionCatalog catalog)
     {
         return new CustomCodeStatementSet($@"
+    if (referenceType == NULL) return;
     referenceType->{SimpleRefCountConstants.CurrentCountFieldName}++;
 ");
     }

--- a/Dntc.Common/OpCodeHandling/Handlers/BranchHandlers.cs
+++ b/Dntc.Common/OpCodeHandling/Handlers/BranchHandlers.cs
@@ -87,7 +87,19 @@ public class BranchHandlers : IOpCodeHandlerCollection
             var items = context.ExpressionStack.Pop(1);
             var item = items[0];
             var target = (Instruction)context.CurrentInstruction.Operand;
-            CBaseExpression condition = new AdjustPointerDepthExpression(item, 0);
+            
+            CBaseExpression condition;
+            if (item.ResultingType.IsReferenceType && item.PointerDepth > 0)
+            {
+                // For reference types, preserve the pointer depth to check the pointer itself (null check)
+                condition = item;
+            }
+            else
+            {
+                // For value types and primitives, dereference to get the value for boolean evaluation
+                condition = new AdjustPointerDepthExpression(item, 0);
+            }
+            
             if (!isTrueCheck)
             {
                 condition = new NegateExpression(condition, true);

--- a/Samples/Scratchpad/ScratchpadCSharp/ReferenceTypes/BasicClassSupportTests.cs
+++ b/Samples/Scratchpad/ScratchpadCSharp/ReferenceTypes/BasicClassSupportTests.cs
@@ -129,8 +129,13 @@ public static class BasicClassSupportTests
     }
 
     // Method that takes an instance but never creates one
-    private static int UseNeverInstantiatedClass(NeverInstantiatedClass instance)
+    private static int UseNeverInstantiatedClass(NeverInstantiatedClass? instance)
     {
+        if (instance == null)
+        {
+            return -1;
+        }
+
         return instance.Value;
     }
 }

--- a/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp_ReferenceTypes.c
+++ b/Samples/Scratchpad/scratchpad_c/generated/ScratchpadCSharp_ReferenceTypes.c
@@ -378,6 +378,14 @@ ScratchpadCSharp_ReferenceTypes_BasicClassSupportTests_NeverInstantiatedClass* S
 int32_t ScratchpadCSharp_ReferenceTypes_BasicClassSupportTests_UseNeverInstantiatedClass(ScratchpadCSharp_ReferenceTypes_BasicClassSupportTests_NeverInstantiatedClass *instance) {
 	int32_t __return_value = {0};
 	DntcReferenceTypeBase_Gc_Track((DntcReferenceTypeBase*)instance);
+	if (instance) {
+		goto ScratchpadCSharp_ReferenceTypes_BasicClassSupportTests_UseNeverInstantiatedClass_IL_0005;
+	}
+	__return_value = -1;
+	DntcReferenceTypeBase_Gc_Untrack((DntcReferenceTypeBase**)&instance);
+	return __return_value;
+
+ScratchpadCSharp_ReferenceTypes_BasicClassSupportTests_UseNeverInstantiatedClass_IL_0005:
 	__return_value = (instance->Value);
 	DntcReferenceTypeBase_Gc_Untrack((DntcReferenceTypeBase**)&instance);
 	return __return_value;

--- a/Samples/Scratchpad/scratchpad_c/generated/dntc.c
+++ b/Samples/Scratchpad/scratchpad_c/generated/dntc.c
@@ -16,5 +16,6 @@ void DntcReferenceTypeBase_Gc_Untrack(DntcReferenceTypeBase **referenceType) {
 
 void DntcReferenceTypeBase_Gc_Track(DntcReferenceTypeBase *referenceType) {
 
+    if (referenceType == NULL) return;
     referenceType->activeReferenceCount++;
 }

--- a/Samples/Scratchpad/scratchpad_c/main.c
+++ b/Samples/Scratchpad/scratchpad_c/main.c
@@ -276,6 +276,10 @@ int main(void) {
     int32_t neverInstantiatedResult = ScratchpadCSharp_ReferenceTypes_BasicClassSupportTests_UseNeverInstantiatedClass(neverInstantiated);
     assert(neverInstantiatedResult == 42); // Should return the Value field directly
     
+    // Test null check behavior - should return -1 when NULL is passed
+    int32_t nullResult = ScratchpadCSharp_ReferenceTypes_BasicClassSupportTests_UseNeverInstantiatedClass(NULL);
+    assert(nullResult == -1); // Should return -1 for null parameter
+    
     // Clean up
     DntcReferenceTypeBase_Gc_Untrack((DntcReferenceTypeBase**)&neverInstantiated);
     DntcReferenceTypeBase_Gc_Untrack((DntcReferenceTypeBase**)&testParent);


### PR DESCRIPTION
When a null check for a reference type was transpiled, the reference type argument was being dereference and causing a seg fault. This fixes the situation by ensuring that a bool check against a reference type is not dereferenced.